### PR TITLE
Port all bindings from MediaPipeUnityPlugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,7 @@ csharp_style_namespace_declarations = block_scoped:warning
 dotnet_diagnostic.IDE0073.severity = error
 
 # Unused usings
-dotnet_diagnostic.IDE0005.severity = error
+dotnet_diagnostic.IDE0005.severity = warning
 
 # Language Style Rules
 csharp_style_var_for_built_in_types = false

--- a/Mediapipe.Net/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraph.cs
@@ -1,0 +1,217 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Google.Protobuf;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Gpu;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework
+{
+    public class CalculatorGraph : MpResourceHandle
+    {
+        public delegate IntPtr NativePacketCallback(IntPtr graphPtr, IntPtr packetPtr);
+        public delegate Status PacketCallback<TPacket, TValue>(TPacket? packet) where TPacket : Packet<TValue>;
+
+        public CalculatorGraph() : base()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__(out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public CalculatorGraph(string textFormatConfig) : base()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__PKc(textFormatConfig, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public CalculatorGraph(byte[] serializedConfig) : base()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__PKc_i(serializedConfig, serializedConfig.Length, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public CalculatorGraph(CalculatorGraphConfig config) : this(config.ToByteArray()) { }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_CalculatorGraph__delete(Ptr);
+
+        public Status Initialize(CalculatorGraphConfig config)
+        {
+            var bytes = config.ToByteArray();
+            UnsafeNativeMethods.mp_CalculatorGraph__Initialize__PKc_i(MpPtr, bytes, bytes.Length, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status Initialize(CalculatorGraphConfig config, SidePacket sidePacket)
+        {
+            var bytes = config.ToByteArray();
+            UnsafeNativeMethods.mp_CalculatorGraph__Initialize__PKc_i_Rsp(MpPtr, bytes, bytes.Length, sidePacket.MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        /// <remarks>Crashes if config is not set</remarks>
+        public CalculatorGraphConfig Config()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__Config(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var config = serializedProto.Deserialize(CalculatorGraphConfig.Parser);
+            serializedProto.Dispose();
+
+            return config;
+        }
+
+        public Status ObserveOutputStream(string streamName, NativePacketCallback nativePacketCallback, bool observeTimestampBounds = false)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(MpPtr, streamName, nativePacketCallback, observeTimestampBounds, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status ObserveOutputStream<TPacket, TValue>(string streamName, PacketCallback<TPacket, TValue> packetCallback, bool observeTimestampBounds, out GCHandle callbackHandle) where TPacket : Packet<TValue>
+        {
+            NativePacketCallback nativePacketCallback = (_, packetPtr) =>
+            {
+                Status status;
+                try
+                {
+                    var packet = (TPacket?)Activator.CreateInstance(typeof(TPacket), packetPtr, false);
+                    status = packetCallback(packet);
+                }
+                catch (Exception e)
+                {
+                    status = Status.FailedPrecondition(e.ToString());
+                }
+                return status.MpPtr;
+            };
+            callbackHandle = GCHandle.Alloc(nativePacketCallback, GCHandleType.Pinned);
+
+            return ObserveOutputStream(streamName, nativePacketCallback, observeTimestampBounds);
+        }
+
+        public Status ObserveOutputStream<TPacket, TValue>(string streamName, PacketCallback<TPacket, TValue> packetCallback, out GCHandle callbackHandle) where TPacket : Packet<TValue>
+            => ObserveOutputStream(streamName, packetCallback, false, out callbackHandle);
+
+        public StatusOrPoller<T> AddOutputStreamPoller<T>(string streamName, bool observeTimestampBounds = false)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__AddOutputStreamPoller__PKc_b(MpPtr, streamName, observeTimestampBounds, out var statusOrPollerPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new StatusOrPoller<T>(statusOrPollerPtr);
+        }
+
+        public Status Run() => Run(new SidePacket());
+
+        public Status Run(SidePacket sidePacket)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__Run__Rsp(MpPtr, sidePacket.MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(sidePacket);
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status StartRun() => StartRun(new SidePacket());
+
+        public Status StartRun(SidePacket sidePacket)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__StartRun__Rsp(MpPtr, sidePacket.MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(sidePacket);
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status WaitUntilIdle()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__WaitUntilIdle(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status WaitUntilDone()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__WaitUntilDone(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public bool HasError() => SafeNativeMethods.mp_CalculatorGraph__HasError(MpPtr);
+
+        public Status AddPacketToInputStream<T>(string streamName, Packet<T> packet)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__AddPacketToInputStream__PKc_Ppacket(MpPtr, streamName, packet.MpPtr, out var statusPtr).Assert();
+            packet.Dispose(); // respect move semantics
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status SetInputStreamMaxQueueSize(string streamName, int maxQueueSize)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__SetInputStreamMaxQueueSize__PKc_i(MpPtr, streamName, maxQueueSize, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status CloseInputStream(string streamName)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__CloseInputStream__PKc(MpPtr, streamName, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public Status CloseAllPacketSources()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__CloseAllPacketSources(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        public void Cancel()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__Cancel(MpPtr).Assert();
+            GC.KeepAlive(this);
+        }
+
+        public bool GraphInputStreamsClosed() => SafeNativeMethods.mp_CalculatorGraph__GraphInputStreamsClosed(MpPtr);
+
+        public bool IsNodeThrottled(int nodeId) => SafeNativeMethods.mp_CalculatorGraph__IsNodeThrottled__i(MpPtr, nodeId);
+
+        public bool UnthrottleSources() => SafeNativeMethods.mp_CalculatorGraph__UnthrottleSources(MpPtr);
+
+        public GpuResources GetGpuResources()
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__GetGpuResources(MpPtr, out var gpuResourcesPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new GpuResources(gpuResourcesPtr);
+        }
+
+        public Status SetGpuResources(GpuResources gpuResources)
+        {
+            UnsafeNativeMethods.mp_CalculatorGraph__SetGpuResources__SPgpu(MpPtr, gpuResources.SharedPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(gpuResources);
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/CalculatorGraphConfigExtension.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraphConfigExtension.cs
@@ -1,0 +1,25 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+using Google.Protobuf;
+
+namespace Mediapipe.Net.Framework
+{
+    public static class CalculatorGraphConfigExtension
+    {
+        public static CalculatorGraphConfig ParseFromTextFormat(this MessageParser<CalculatorGraphConfig> _, string configText)
+        {
+            if (UnsafeNativeMethods.mp_api__ConvertFromCalculatorGraphConfigTextFormat(configText, out var serializedProto))
+            {
+                var config = serializedProto.Deserialize(CalculatorGraphConfig.Parser);
+                serializedProto.Dispose();
+                return config;
+            }
+            throw new MediapipeException("Failed to parse config text. See error logs for more details");
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/CalculatorGraphConfigExtension.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraphConfigExtension.cs
@@ -2,10 +2,10 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
+using Google.Protobuf;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Framework.Protobuf;
 using Mediapipe.Net.Native;
-using Google.Protobuf;
 
 namespace Mediapipe.Net.Framework
 {

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -1,0 +1,259 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Format
+{
+    public class ImageFrame : MpResourceHandle
+    {
+        public static readonly uint DefaultAlignmentBoundary = 16;
+        public static readonly uint GlDefaultAlignmentBoundary = 4;
+
+        public delegate void Deleter(IntPtr ptr);
+
+        public ImageFrame() : base()
+        {
+            UnsafeNativeMethods.mp_ImageFrame__(out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public ImageFrame(IntPtr imageFramePtr, bool isOwner = true) : base(imageFramePtr, isOwner) { }
+
+        public ImageFrame(ImageFormat format, int width, int height) : this(format, width, height, DefaultAlignmentBoundary) { }
+
+        public ImageFrame(ImageFormat format, int width, int height, uint alignmentBoundary) : base()
+        {
+            UnsafeNativeMethods.mp_ImageFrame__ui_i_i_ui(format, width, height, alignmentBoundary, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        // NOTE: This byte* was a NativeArray<byte> from Unity. See if it adapts.
+        unsafe public ImageFrame(ImageFormat format, int width, int height, int widthStep, byte* pixelData)
+        {
+            unsafe
+            {
+                UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
+                  format, width, height, widthStep,
+                  (IntPtr)pixelData,
+                  releasePixelData,
+                  out var ptr
+                ).Assert();
+                Ptr = ptr;
+            }
+        }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_ImageFrame__delete(Ptr);
+
+        // [AOT.MonoPInvokeCallback(typeof(Deleter))] (?)
+        private static void releasePixelData(IntPtr ptr)
+        {
+            // Do nothing (pixelData is moved)
+        }
+
+        public bool IsEmpty() => SafeNativeMethods.mp_ImageFrame__IsEmpty(MpPtr);
+
+        public bool IsContiguous() => SafeNativeMethods.mp_ImageFrame__IsContiguous(MpPtr);
+
+        public bool IsAligned(uint alignmentBoundary)
+        {
+            SafeNativeMethods.mp_ImageFrame__IsAligned__ui(MpPtr, alignmentBoundary, out var value).Assert();
+
+            GC.KeepAlive(this);
+            return value;
+        }
+
+        public ImageFormat Format() => SafeNativeMethods.mp_ImageFrame__Format(MpPtr);
+
+        public int Width() => SafeNativeMethods.mp_ImageFrame__Width(MpPtr);
+
+        public int Height() => SafeNativeMethods.mp_ImageFrame__Height(MpPtr);
+
+        public int ChannelSize()
+        {
+            var code = SafeNativeMethods.mp_ImageFrame__ChannelSize(MpPtr, out var value);
+
+            GC.KeepAlive(this);
+            return valueOrFormatException(code, value);
+        }
+
+        public int NumberOfChannels()
+        {
+            var code = SafeNativeMethods.mp_ImageFrame__NumberOfChannels(MpPtr, out var value);
+
+            GC.KeepAlive(this);
+            return valueOrFormatException(code, value);
+        }
+
+        public int ByteDepth()
+        {
+            var code = SafeNativeMethods.mp_ImageFrame__ByteDepth(MpPtr, out var value);
+
+            GC.KeepAlive(this);
+            return valueOrFormatException(code, value);
+        }
+
+        public int WidthStep() => SafeNativeMethods.mp_ImageFrame__WidthStep(MpPtr);
+
+        public IntPtr MutablePixelData() => SafeNativeMethods.mp_ImageFrame__MutablePixelData(MpPtr);
+
+        public int PixelDataSize() => SafeNativeMethods.mp_ImageFrame__PixelDataSize(MpPtr);
+
+        public int PixelDataSizeStoredContiguously()
+        {
+            var code = SafeNativeMethods.mp_ImageFrame__PixelDataSizeStoredContiguously(MpPtr, out var value);
+
+            GC.KeepAlive(this);
+            return valueOrFormatException(code, value);
+        }
+
+        public void SetToZero()
+        {
+            UnsafeNativeMethods.mp_ImageFrame__SetToZero(MpPtr).Assert();
+            GC.KeepAlive(this);
+        }
+
+        public void SetAlignmentPaddingAreas()
+        {
+            UnsafeNativeMethods.mp_ImageFrame__SetAlignmentPaddingAreas(MpPtr).Assert();
+            GC.KeepAlive(this);
+        }
+
+        public byte[] CopyToByteBuffer(int bufferSize)
+            => copyToBuffer<byte>(UnsafeNativeMethods.mp_ImageFrame__CopyToBuffer__Pui8_i, bufferSize);
+
+        public ushort[] CopyToUshortBuffer(int bufferSize)
+            => copyToBuffer<ushort>(UnsafeNativeMethods.mp_ImageFrame__CopyToBuffer__Pui16_i, bufferSize);
+
+        public float[] CopyToFloatBuffer(int bufferSize)
+            => copyToBuffer<float>(UnsafeNativeMethods.mp_ImageFrame__CopyToBuffer__Pf_i, bufferSize);
+
+
+        /// <summary>
+        ///   Get the value of a specific channel only.
+        ///   It's useful when only one channel is used (e.g. Hair Segmentation mask).
+        /// </summary>
+        /// <param name="channelNumber">
+        ///   Specify from which channel the data will be retrieved.
+        ///   For example, if the format is RGB, 0 means R channel, 1 means G channel, and 2 means B channel.
+        /// </param>
+        /// <param name="colors" >
+        ///   The array to which the output data will be written.
+        /// </param>
+        public byte[] GetChannel(int channelNumber, bool flipVertically, byte[] colors)
+        {
+            var format = Format();
+
+            switch (format)
+            {
+                case ImageFormat.Srgb:
+                    if (channelNumber < 0 || channelNumber > 3)
+                        throw new ArgumentException($"There are only 3 channels, but No. {channelNumber} is specified");
+                    readChannel(MutablePixelData(), channelNumber, 3, Width(), Height(), WidthStep(), flipVertically, colors);
+                    return colors;
+                case ImageFormat.Srgba:
+                    if (channelNumber < 0 || channelNumber > 4)
+                        throw new ArgumentException($"There are only 4 channels, but No. {channelNumber} is specified");
+                    readChannel(MutablePixelData(), channelNumber, 4, Width(), Height(), WidthStep(), flipVertically, colors);
+                    return colors;
+                default:
+                    throw new NotImplementedException($"Currently only SRGB and SRGBA format are supported: {format}");
+            }
+        }
+
+        /// <summary>
+        ///   Get the value of a specific channel only.
+        ///   It's useful when only one channel is used (e.g. Hair Segmentation mask).
+        /// </summary>
+        /// <param name="channelNumber">
+        ///   Specify from which channel the data will be retrieved.
+        ///   For example, if the format is RGB, 0 means R channel, 1 means G channel, and 2 means B channel.
+        /// </param>
+        public byte[] GetChannel(int channelNumber, bool flipVertically)
+            => GetChannel(channelNumber, flipVertically, new byte[Width() * Height()]);
+
+        private delegate MpReturnCode CopyToBufferHandler(IntPtr ptr, IntPtr buffer, int bufferSize);
+
+        private T[] copyToBuffer<T>(CopyToBufferHandler handler, int bufferSize) where T : unmanaged
+        {
+            var buffer = new T[bufferSize];
+
+            unsafe
+            {
+                fixed (T* bufferPtr = buffer)
+                {
+                    handler(MpPtr, (IntPtr)bufferPtr, bufferSize).Assert();
+                }
+            }
+
+            GC.KeepAlive(this);
+            return buffer;
+        }
+
+        private T valueOrFormatException<T>(MpReturnCode code, T value)
+        {
+            try
+            {
+                code.Assert();
+                return value;
+            }
+            catch (MediapipeException)
+            {
+                throw new FormatException($"Invalid image format: {Format()}");
+            }
+        }
+
+        /// <remarks>
+        /// In the source array, pixels are laid out left to right, top to bottom,
+        /// but in the returned array, left to right, top to bottom.
+        /// </remarks>
+        private static void readChannel(IntPtr ptr, int channelNumber, int channelCount, int width, int height, int widthStep, bool flipVertically, byte[] colors)
+        {
+            if (colors.Length != width * height)
+                throw new ArgumentException("colors length is invalid");
+            var padding = widthStep - channelCount * width;
+
+            unsafe
+            {
+                fixed (byte* dest = colors)
+                {
+                    var pSrc = (byte*)ptr.ToPointer();
+                    pSrc += channelNumber;
+
+                    if (flipVertically)
+                    {
+                        var pDest = dest + colors.Length - 1;
+
+                        for (var i = 0; i < height; i++)
+                        {
+                            for (var j = 0; j < width; j++)
+                            {
+                                *pDest-- = *pSrc;
+                                pSrc += channelCount;
+                            }
+                            pSrc += padding;
+                        }
+                    }
+                    else
+                    {
+                        var pDest = dest + width * (height - 1);
+
+                        for (var i = 0; i < height; i++)
+                        {
+                            for (var j = 0; j < width; j++)
+                            {
+                                *pDest++ = *pSrc;
+                                pSrc += channelCount;
+                            }
+                            pSrc += padding;
+                            pDest -= 2 * width;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -31,19 +31,22 @@ namespace Mediapipe.Net.Framework.Format
             Ptr = ptr;
         }
 
-        // NOTE: This byte* was a NativeArray<byte> from Unity. See if it adapts.
+        // NOTE: This byte* was a NativeArray<byte> from Unity.
+        // It will naturally translate to C++'s uint8*.
+        // The signature on the native side is:
+        //
+        // MP_CAPI(MpReturnCode) mp_ImageFrame__ui_i_i_i_Pui8_PF(
+        //     mediapipe::ImageFormat::Format format,
+        //     int width, int height, int width_step, uint8* pixel_data,
+        //     Deleter* deleter, mediapipe::ImageFrame** image_frame_out);
         unsafe public ImageFrame(ImageFormat format, int width, int height, int widthStep, byte* pixelData)
         {
-            unsafe
-            {
-                UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
-                  format, width, height, widthStep,
-                  (IntPtr)pixelData,
-                  releasePixelData,
-                  out var ptr
-                ).Assert();
-                Ptr = ptr;
-            }
+            UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
+                format, width, height, widthStep,
+                (IntPtr)pixelData,
+                releasePixelData,
+                out var ptr).Assert();
+            Ptr = ptr;
         }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_ImageFrame__delete(Ptr);

--- a/Mediapipe.Net/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Framework/OutputStreamPoller.cs
@@ -1,0 +1,41 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework
+{
+    public class OutputStreamPoller<T> : MpResourceHandle
+    {
+        public OutputStreamPoller(IntPtr ptr) : base(ptr) { }
+
+        protected override void DeleteMpPtr()
+        {
+            UnsafeNativeMethods.mp_OutputStreamPoller__delete(Ptr);
+        }
+
+        public bool Next(Packet<T> packet)
+        {
+            UnsafeNativeMethods.mp_OutputStreamPoller__Next_Ppacket(MpPtr, packet.MpPtr, out var result).Assert();
+
+            GC.KeepAlive(this);
+            return result;
+        }
+
+        public void Reset() => UnsafeNativeMethods.mp_OutputStreamPoller__Reset(MpPtr).Assert();
+
+        public void SetMaxQueueSize(int queueSize) => UnsafeNativeMethods.mp_OutputStreamPoller__SetMaxQueueSize(MpPtr, queueSize).Assert();
+
+        public int QueueSize()
+        {
+            UnsafeNativeMethods.mp_OutputStreamPoller__QueueSize(MpPtr, out var result).Assert();
+
+            GC.KeepAlive(this);
+            return result;
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
@@ -1,0 +1,44 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Graphs.InstantMotionTracking;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class Anchor3dVectorPacket : Packet<List<Anchor3d>>
+    {
+        public Anchor3dVectorPacket() : base() { }
+        public Anchor3dVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public Anchor3dVectorPacket(Anchor3d[] value) : base()
+        {
+            UnsafeNativeMethods.mp__MakeAnchor3dVectorPacket__PA_i(value, value.Length, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public Anchor3dVectorPacket(Anchor3d[] value, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeAnchor3dVectorPacket_At__PA_i_Rt(value, value.Length, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+        }
+
+        public override List<Anchor3d> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetAnchor3dVector(MpPtr, out var anchorVector).Assert();
+            GC.KeepAlive(this);
+
+            var anchors = anchorVector.ToList();
+            anchorVector.Dispose();
+
+            return anchors;
+        }
+
+        public override StatusOr<List<Anchor3d>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/BoolPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/BoolPacket.cs
@@ -1,0 +1,48 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class BoolPacket : Packet<bool>
+    {
+        public BoolPacket() : base() { }
+
+        public BoolPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public BoolPacket(bool value) : base()
+        {
+            UnsafeNativeMethods.mp__MakeBoolPacket__b(value, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public BoolPacket(bool value, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeBoolPacket_At__b_Rt(value, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+        }
+
+        public override bool Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetBool(MpPtr, out var value).Assert();
+
+            GC.KeepAlive(this);
+            return value;
+        }
+
+        public override StatusOr<bool> Consume() => throw new NotSupportedException();
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsBool(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class ClassificationListPacket : Packet<ClassificationList>
+    {
+        public ClassificationListPacket() : base() { }
+        public ClassificationListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override ClassificationList Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetClassificationList(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var classificationList = serializedProto.Deserialize(ClassificationList.Parser);
+            serializedProto.Dispose();
+
+            return classificationList;
+        }
+
+        public override StatusOr<ClassificationList> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class ClassificationListVectorPacket : Packet<List<ClassificationList>>
+    {
+        public ClassificationListVectorPacket() : base() { }
+        public ClassificationListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<ClassificationList> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetClassificationListVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var classificationLists = serializedProtoVector.Deserialize(ClassificationList.Parser);
+            serializedProtoVector.Dispose();
+
+            return classificationLists;
+        }
+
+        public override StatusOr<List<ClassificationList>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class DetectionPacket : Packet<Detection>
+    {
+        public DetectionPacket() : base() { }
+        public DetectionPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override Detection Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetDetection(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var detection = serializedProto.Deserialize(Detection.Parser);
+            serializedProto.Dispose();
+
+            return detection;
+        }
+
+        public override StatusOr<Detection> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class DetectionVectorPacket : Packet<List<Detection>>
+    {
+        public DetectionVectorPacket() : base() { }
+        public DetectionVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<Detection> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetDetectionVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var detections = serializedProtoVector.Deserialize(Detection.Parser);
+            serializedProtoVector.Dispose();
+
+            return detections;
+        }
+
+        public override StatusOr<List<Detection>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
@@ -1,0 +1,29 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class FaceGeometryPacket : Packet<FaceGeometry.FaceGeometry>
+    {
+        public FaceGeometryPacket() : base() { }
+        public FaceGeometryPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override FaceGeometry.FaceGeometry Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetFaceGeometry(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var geometry = serializedProto.Deserialize(FaceGeometry.FaceGeometry.Parser);
+            serializedProto.Dispose();
+
+            return geometry;
+        }
+
+        public override StatusOr<FaceGeometry.FaceGeometry> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class FaceGeometryVectorPacket : Packet<List<FaceGeometry.FaceGeometry>>
+    {
+        public FaceGeometryVectorPacket() : base() { }
+        public FaceGeometryVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<FaceGeometry.FaceGeometry> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetFaceGeometryVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var geometries = serializedProtoVector.Deserialize(FaceGeometry.FaceGeometry.Parser);
+            serializedProtoVector.Dispose();
+
+            return geometries;
+        }
+
+        public override StatusOr<List<FaceGeometry.FaceGeometry>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -1,0 +1,83 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class FloatArrayPacket : Packet<float[]>
+    {
+        private int length = -1;
+
+        public int Length
+        {
+            get => length;
+            set
+            {
+                if (length >= 0)
+                    throw new InvalidOperationException("Length is already set and cannot be changed");
+
+                length = value;
+            }
+        }
+
+        public FloatArrayPacket() : base() { }
+
+        public FloatArrayPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public FloatArrayPacket(float[] value) : base()
+        {
+            UnsafeNativeMethods.mp__MakeFloatArrayPacket__Pf_i(value, value.Length, out var ptr).Assert();
+            Ptr = ptr;
+            Length = value.Length;
+        }
+
+        public FloatArrayPacket(float[] value, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeFloatArrayPacket_At__Pf_i_Rt(value, value.Length, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+            Length = value.Length;
+        }
+
+        public override float[] Get()
+        {
+            if (Length < 0)
+                throw new InvalidOperationException("The array's length is unknown, set Length first");
+
+            var result = new float[Length];
+
+            unsafe
+            {
+                var src = (float*)GetArrayPtr();
+
+                for (var i = 0; i < result.Length; i++)
+                {
+                    result[i] = *src++;
+                }
+            }
+
+            return result;
+        }
+
+        public IntPtr GetArrayPtr()
+        {
+            UnsafeNativeMethods.mp_Packet__GetFloatArray(MpPtr, out var value).Assert();
+            GC.KeepAlive(this);
+            return value;
+        }
+
+        public override StatusOr<float[]> Consume() => throw new NotSupportedException();
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsFloatArray(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/FloatPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatPacket.cs
@@ -1,0 +1,48 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class FloatPacket : Packet<float>
+    {
+        public FloatPacket() : base() { }
+
+        public FloatPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public FloatPacket(float value) : base()
+        {
+            UnsafeNativeMethods.mp__MakeFloatPacket__f(value, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public FloatPacket(float value, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeFloatPacket_At__f_Rt(value, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+        }
+
+        public override float Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetFloat(MpPtr, out var value).Assert();
+
+            GC.KeepAlive(this);
+            return value;
+        }
+
+        public override StatusOr<float> Consume() => throw new NotSupportedException();
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsFloat(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe
+{
+    public class FrameAnnotationPacket : Packet<FrameAnnotation>
+    {
+        public FrameAnnotationPacket() : base() { }
+        public FrameAnnotationPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override FrameAnnotation Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetFrameAnnotation(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var frameAnnotation = serializedProto.Deserialize(FrameAnnotation.Parser);
+            serializedProto.Dispose();
+
+            return frameAnnotation;
+        }
+
+        public override StatusOr<FrameAnnotation> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
@@ -1,0 +1,58 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Gpu;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class GpuBufferPacket : Packet<GpuBuffer>
+    {
+        public GpuBufferPacket() : base() { }
+        public GpuBufferPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public GpuBufferPacket(GpuBuffer gpuBuffer) : base()
+        {
+            UnsafeNativeMethods.mp__MakeGpuBufferPacket__Rgb(gpuBuffer.MpPtr, out var ptr).Assert();
+            gpuBuffer.Dispose(); // respect move semantics
+
+            Ptr = ptr;
+        }
+
+        public GpuBufferPacket(GpuBuffer gpuBuffer, Timestamp timestamp)
+        {
+            UnsafeNativeMethods.mp__MakeGpuBufferPacket_At__Rgb_Rts(gpuBuffer.MpPtr, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            gpuBuffer.Dispose(); // respect move semantics
+
+            Ptr = ptr;
+        }
+
+        public override GpuBuffer Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetGpuBuffer(MpPtr, out var gpuBufferPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new GpuBuffer(gpuBufferPtr, false);
+        }
+
+        public override StatusOr<GpuBuffer> Consume()
+        {
+            UnsafeNativeMethods.mp_Packet__ConsumeGpuBuffer(MpPtr, out var statusOrGpuBufferPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new StatusOrGpuBuffer(statusOrGpuBufferPtr);
+        }
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsGpuBuffer(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
@@ -1,0 +1,59 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Format;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class ImageFramePacket : Packet<ImageFrame>
+    {
+        public ImageFramePacket() : base() { }
+
+        public ImageFramePacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public ImageFramePacket(ImageFrame imageFrame) : base()
+        {
+            UnsafeNativeMethods.mp__MakeImageFramePacket__Pif(imageFrame.MpPtr, out var ptr).Assert();
+            imageFrame.Dispose(); // respect move semantics
+
+            Ptr = ptr;
+        }
+
+        public ImageFramePacket(ImageFrame imageFrame, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeImageFramePacket_At__Pif_Rt(imageFrame.MpPtr, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            imageFrame.Dispose(); // respect move semantics
+
+            Ptr = ptr;
+        }
+
+        public override ImageFrame Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetImageFrame(MpPtr, out var imageFramePtr).Assert();
+
+            GC.KeepAlive(this);
+            return new ImageFrame(imageFramePtr, false);
+        }
+
+        public override StatusOr<ImageFrame> Consume()
+        {
+            UnsafeNativeMethods.mp_Packet__ConsumeImageFrame(MpPtr, out var statusOrImageFramePtr).Assert();
+
+            GC.KeepAlive(this);
+            return new StatusOrImageFrame(statusOrImageFramePtr);
+        }
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsImageFrame(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/IntPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/IntPacket.cs
@@ -1,0 +1,48 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class IntPacket : Packet<int>
+    {
+        public IntPacket() : base() { }
+
+        public IntPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public IntPacket(int value) : base()
+        {
+            UnsafeNativeMethods.mp__MakeIntPacket__i(value, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public IntPacket(int value, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeIntPacket_At__i_Rt(value, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+        }
+
+        public override int Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetInt(MpPtr, out var value).Assert();
+
+            GC.KeepAlive(this);
+            return value;
+        }
+
+        public override StatusOr<int> Consume() => throw new NotSupportedException();
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsInt(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class LandmarkListPacket : Packet<LandmarkList>
+    {
+        public LandmarkListPacket() : base() { }
+        public LandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override LandmarkList Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetLandmarkList(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var landmarkList = serializedProto.Deserialize(LandmarkList.Parser);
+            serializedProto.Dispose();
+
+            return landmarkList;
+        }
+
+        public override StatusOr<LandmarkList> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class LandmarkListVectorPacket : Packet<List<LandmarkList>>
+    {
+        public LandmarkListVectorPacket() : base() { }
+        public LandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<LandmarkList> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetLandmarkListVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var landmarkLists = serializedProtoVector.Deserialize(LandmarkList.Parser);
+            serializedProtoVector.Dispose();
+
+            return landmarkLists;
+        }
+
+        public override StatusOr<List<LandmarkList>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class NormalizedLandmarkListPacket : Packet<NormalizedLandmarkList>
+    {
+        public NormalizedLandmarkListPacket() : base() { }
+        public NormalizedLandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override NormalizedLandmarkList Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetNormalizedLandmarkList(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var normalizedLandmarkList = serializedProto.Deserialize(NormalizedLandmarkList.Parser);
+            serializedProto.Dispose();
+
+            return normalizedLandmarkList;
+        }
+
+        public override StatusOr<NormalizedLandmarkList> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class NormalizedLandmarkListVectorPacket : Packet<List<NormalizedLandmarkList>>
+    {
+        public NormalizedLandmarkListVectorPacket() : base() { }
+        public NormalizedLandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<NormalizedLandmarkList> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetNormalizedLandmarkListVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var normalizedLandmarkLists = serializedProtoVector.Deserialize(NormalizedLandmarkList.Parser);
+            serializedProtoVector.Dispose();
+
+            return normalizedLandmarkLists;
+        }
+
+        public override StatusOr<List<NormalizedLandmarkList>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class NormalizedRectPacket : Packet<NormalizedRect>
+    {
+        public NormalizedRectPacket() : base() { }
+        public NormalizedRectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override NormalizedRect Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetNormalizedRect(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var normalizedRect = serializedProto.Deserialize(NormalizedRect.Parser);
+            serializedProto.Dispose();
+
+            return normalizedRect;
+        }
+
+        public override StatusOr<NormalizedRect> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class NormalizedRectVectorPacket : Packet<List<NormalizedRect>>
+    {
+        public NormalizedRectVectorPacket() : base() { }
+        public NormalizedRectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<NormalizedRect> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetNormalizedRectVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var normalizedRects = serializedProtoVector.Deserialize(NormalizedRect.Parser);
+            serializedProtoVector.Dispose();
+
+            return normalizedRects;
+        }
+
+        public override StatusOr<List<NormalizedRect>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -1,0 +1,73 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public abstract class Packet<T> : MpResourceHandle
+    {
+        public Packet() : base()
+        {
+            UnsafeNativeMethods.mp_Packet__(out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public Packet(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        /// <exception cref="MediaPipeException">Thrown when the value is not set</exception>
+        public abstract T Get();
+
+        public abstract StatusOr<T> Consume();
+
+        /// <remarks>To avoid copying the value, instantiate the packet with timestamp</remarks>
+        /// <returns>New packet with the given timestamp and the copied value</returns>
+        public Packet<T>? At(Timestamp timestamp)
+        {
+            UnsafeNativeMethods.mp_Packet__At__Rt(MpPtr, timestamp.MpPtr, out var packetPtr).Assert();
+
+            GC.KeepAlive(timestamp);
+
+            // Oh gosh... the Activator...
+            return (Packet<T>?)Activator.CreateInstance(GetType(), packetPtr, true);
+        }
+
+        public bool IsEmpty() => SafeNativeMethods.mp_Packet__IsEmpty(MpPtr);
+
+        public Status ValidateAsProtoMessageLite()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsProtoMessageLite(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+
+        // TODO: (from homuler) declare as abstract
+        public virtual Status ValidateAsType() => throw new NotImplementedException();
+
+        public Timestamp Timestamp()
+        {
+            UnsafeNativeMethods.mp_Packet__Timestamp(MpPtr, out var timestampPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Timestamp(timestampPtr);
+        }
+
+        public string? DebugString() => MarshalStringFromNative(UnsafeNativeMethods.mp_Packet__DebugString);
+
+        public string RegisteredTypeName()
+        {
+            var typeName = MarshalStringFromNative(UnsafeNativeMethods.mp_Packet__RegisteredTypeName);
+
+            return typeName ?? "";
+        }
+
+        public string? DebugTypeName() => MarshalStringFromNative(UnsafeNativeMethods.mp_Packet__DebugTypeName);
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_Packet__delete(Ptr);
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/RectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class RectPacket : Packet<Rect>
+    {
+        public RectPacket() : base() { }
+        public RectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override Rect Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetRect(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var rect = serializedProto.Deserialize(Rect.Parser);
+            serializedProto.Dispose();
+
+            return rect;
+        }
+
+        public override StatusOr<Rect> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
@@ -1,0 +1,31 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections.Generic;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class RectVectorPacket : Packet<List<Rect>>
+    {
+        public RectVectorPacket() : base() { }
+        public RectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override List<Rect> Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetRectVector(MpPtr, out var serializedProtoVector).Assert();
+            GC.KeepAlive(this);
+
+            var rects = serializedProtoVector.Deserialize(Rect.Parser);
+            serializedProtoVector.Dispose();
+
+            return rects;
+        }
+
+        public override StatusOr<List<Rect>> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/SidePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/SidePacket.cs
@@ -1,0 +1,55 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class SidePacket : MpResourceHandle
+    {
+        public SidePacket() : base()
+        {
+            UnsafeNativeMethods.mp_SidePacket__(out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_SidePacket__delete(Ptr);
+
+        public int Size => SafeNativeMethods.mp_SidePacket__size(MpPtr);
+
+        /// TODO: force T to be Packet
+        /// <remarks>Make sure that the type of the returned packet value is correct</remarks>
+        public T? At<T>(string key)
+        {
+            UnsafeNativeMethods.mp_SidePacket__at__PKc(MpPtr, key, out var packetPtr).Assert();
+
+            if (packetPtr == IntPtr.Zero)
+                return default; // null
+
+            GC.KeepAlive(this);
+
+            // Oh gosh²... the Activator²...
+            return (T?)Activator.CreateInstance(typeof(T), packetPtr, true);
+        }
+
+        public void Emplace<T>(string key, Packet<T> packet)
+        {
+            UnsafeNativeMethods.mp_SidePacket__emplace__PKc_Rp(MpPtr, key, packet.MpPtr).Assert();
+            packet.Dispose(); // respect move semantics
+            GC.KeepAlive(this);
+        }
+
+        public int Erase(string key)
+        {
+            UnsafeNativeMethods.mp_SidePacket__erase__PKc(MpPtr, key, out var count).Assert();
+
+            GC.KeepAlive(this);
+            return count;
+        }
+
+        public void Clear() => SafeNativeMethods.mp_SidePacket__clear(MpPtr);
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -1,0 +1,69 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Runtime.InteropServices;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class StringPacket : Packet<string>
+    {
+        public StringPacket() : base() { }
+
+        public StringPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public StringPacket(string value) : base()
+        {
+            UnsafeNativeMethods.mp__MakeStringPacket__PKc(value, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public StringPacket(byte[] bytes) : base()
+        {
+            UnsafeNativeMethods.mp__MakeStringPacket__PKc_i(bytes, bytes.Length, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public StringPacket(string value, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeStringPacket_At__PKc_Rt(value, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+        }
+
+        public StringPacket(byte[] bytes, Timestamp timestamp) : base()
+        {
+            UnsafeNativeMethods.mp__MakeStringPacket_At__PKc_i_Rt(bytes, bytes.Length, timestamp.MpPtr, out var ptr).Assert();
+            GC.KeepAlive(timestamp);
+            Ptr = ptr;
+        }
+
+        // TODO: review nullability of strings here...
+        public override string Get() => MarshalStringFromNative(UnsafeNativeMethods.mp_Packet__GetString) ?? "";
+
+        public byte[] GetByteArray()
+        {
+            UnsafeNativeMethods.mp_Packet__GetByteString(MpPtr, out var strPtr, out var size).Assert();
+            GC.KeepAlive(this);
+
+            var bytes = new byte[size];
+            Marshal.Copy(strPtr, bytes, 0, size);
+            UnsafeNativeMethods.delete_array__PKc(strPtr);
+
+            return bytes;
+        }
+
+        public override StatusOr<string> Consume() => throw new NotSupportedException();
+
+        public override Status ValidateAsType()
+        {
+            UnsafeNativeMethods.mp_Packet__ValidateAsString(MpPtr, out var statusPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Status(statusPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
@@ -1,0 +1,30 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Packet
+{
+    public class TimedModelMatrixProtoListPacket : Packet<TimedModelMatrixProtoList>
+    {
+        public TimedModelMatrixProtoListPacket() : base() { }
+        public TimedModelMatrixProtoListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        public override TimedModelMatrixProtoList Get()
+        {
+            UnsafeNativeMethods.mp_Packet__GetTimedModelMatrixProtoList(MpPtr, out var serializedProto).Assert();
+            GC.KeepAlive(this);
+
+            var matrixProtoList = serializedProto.Deserialize(TimedModelMatrixProtoList.Parser);
+            serializedProto.Dispose();
+
+            return matrixProtoList;
+        }
+
+        public override StatusOr<TimedModelMatrixProtoList> Consume() => throw new NotSupportedException();
+    }
+}

--- a/Mediapipe.Net/Framework/Port/Status.cs
+++ b/Mediapipe.Net/Framework/Port/Status.cs
@@ -1,0 +1,80 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Port
+{
+    public class Status : MpResourceHandle
+    {
+        public enum StatusCode : int
+        {
+            Ok = 0,
+            Cancelled = 1,
+            Unknown = 2,
+            InvalidArgument = 3,
+            DeadlineExceeded = 4,
+            NotFound = 5,
+            AlreadyExists = 6,
+            PermissionDenied = 7,
+            ResourceExhausted = 8,
+            FailedPrecondition = 9,
+            Aborted = 10,
+            OutOfRange = 11,
+            Unimplemented = 12,
+            Internal = 13,
+            Unavailable = 14,
+            DataLoss = 15,
+            Unauthenticated = 16,
+        }
+
+        public Status(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.absl_Status__delete(Ptr);
+
+        private bool? ok;
+        private int? rawCode;
+
+        public void AssertOk()
+        {
+            if (!Ok())
+                throw new MediapipeException(ToString() ?? "");
+        }
+
+        public bool Ok()
+        {
+            if (ok is bool valueOfOk)
+                return valueOfOk;
+            ok = SafeNativeMethods.absl_Status__ok(MpPtr);
+            return (bool)ok;
+        }
+
+        public StatusCode Code() => (StatusCode)RawCode();
+
+        public int RawCode()
+        {
+            if (rawCode is int valueOfRawCode)
+                return valueOfRawCode;
+
+            rawCode = SafeNativeMethods.absl_Status__raw_code(MpPtr);
+            return (int)rawCode;
+        }
+
+        public override string? ToString() => MarshalStringFromNative(UnsafeNativeMethods.absl_Status__ToString);
+
+        public static Status Build(StatusCode code, string message, bool isOwner = true)
+        {
+            UnsafeNativeMethods.absl_Status__i_PKc((int)code, message, out var ptr).Assert();
+
+            return new Status(ptr, isOwner);
+        }
+
+        public static Status Ok(bool isOwner = true) => Build(StatusCode.Ok, "", isOwner);
+
+        public static Status FailedPrecondition(string message = "", bool isOwner = true)
+            => Build(StatusCode.FailedPrecondition, message, isOwner);
+    }
+}

--- a/Mediapipe.Net/Framework/Port/StatusOr.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOr.cs
@@ -1,0 +1,22 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+
+namespace Mediapipe.Net.Framework.Port
+{
+    public abstract class StatusOr<T> : MpResourceHandle
+    {
+        public StatusOr(IntPtr ptr) : base(ptr) { }
+
+        public abstract Status Status { get; }
+        public virtual bool Ok() => Status.Ok();
+
+        public virtual T? ValueOr(T? defaultValue = default) => Ok() ? Value() : defaultValue;
+
+        /// <exception cref="MediapipeNetException">Thrown when status is not ok</exception>
+        public abstract T Value();
+    }
+}

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Gpu;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Port
+{
+    public class StatusOrGpuBuffer : StatusOr<GpuBuffer>
+    {
+        public StatusOrGpuBuffer(IntPtr ptr) : base(ptr) { }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_StatusOrGpuBuffer__delete(Ptr);
+
+        private Status? status;
+        public override Status Status
+        {
+            get
+            {
+                if (status == null || status.IsDisposed)
+                {
+                    UnsafeNativeMethods.mp_StatusOrGpuBuffer__status(MpPtr, out var statusPtr).Assert();
+
+                    GC.KeepAlive(this);
+                    status = new Status(statusPtr);
+                }
+                return status;
+            }
+        }
+
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrGpuBuffer__ok(MpPtr);
+
+        public override GpuBuffer Value()
+        {
+            UnsafeNativeMethods.mp_StatusOrGpuBuffer__value(MpPtr, out var gpuBufferPtr).Assert();
+            Dispose();
+
+            return new GpuBuffer(gpuBufferPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
@@ -1,0 +1,46 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Gpu;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Port
+{
+    public class StatusOrGpuResources : StatusOr<GpuResources>
+    {
+        public StatusOrGpuResources(IntPtr ptr) : base(ptr) { }
+
+        protected override void DeleteMpPtr()
+        {
+            UnsafeNativeMethods.mp_StatusOrGpuResources__delete(Ptr);
+        }
+
+        private Status? status;
+        public override Status Status
+        {
+            get
+            {
+                if (status == null || status.IsDisposed)
+                {
+                    UnsafeNativeMethods.mp_StatusOrGpuResources__status(MpPtr, out var statusPtr).Assert();
+
+                    GC.KeepAlive(this);
+                    status = new Status(statusPtr);
+                }
+                return status;
+            }
+        }
+
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrGpuResources__ok(MpPtr);
+
+        public override GpuResources Value()
+        {
+            UnsafeNativeMethods.mp_StatusOrGpuResources__value(MpPtr, out var gpuResourcesPtr).Assert();
+            Dispose();
+
+            return new GpuResources(gpuResourcesPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
@@ -1,0 +1,46 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Format;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Port
+{
+    public class StatusOrImageFrame : StatusOr<ImageFrame>
+    {
+        public StatusOrImageFrame(IntPtr ptr) : base(ptr) { }
+
+        protected override void DeleteMpPtr()
+        {
+            UnsafeNativeMethods.mp_StatusOrImageFrame__delete(Ptr);
+        }
+
+        private Status? status;
+        public override Status Status
+        {
+            get
+            {
+                if (status == null || status.IsDisposed)
+                {
+                    UnsafeNativeMethods.mp_StatusOrImageFrame__status(MpPtr, out var statusPtr).Assert();
+
+                    GC.KeepAlive(this);
+                    status = new Status(statusPtr);
+                }
+                return status;
+            }
+        }
+
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrImageFrame__ok(MpPtr);
+
+        public override ImageFrame Value()
+        {
+            UnsafeNativeMethods.mp_StatusOrImageFrame__value(MpPtr, out var imageFramePtr).Assert();
+            Dispose();
+
+            return new ImageFrame(imageFramePtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
@@ -1,0 +1,42 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework.Port
+{
+    public class StatusOrPoller<T> : StatusOr<OutputStreamPoller<T>>
+    {
+        public StatusOrPoller(IntPtr ptr) : base(ptr) { }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_StatusOrPoller__delete(Ptr);
+
+        private Status? status;
+        public override Status Status
+        {
+            get
+            {
+                if (status == null || status.IsDisposed)
+                {
+                    UnsafeNativeMethods.mp_StatusOrPoller__status(MpPtr, out var statusPtr).Assert();
+
+                    GC.KeepAlive(this);
+                    status = new Status(statusPtr);
+                }
+                return status;
+            }
+        }
+
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrPoller__ok(MpPtr);
+
+        public override OutputStreamPoller<T> Value()
+        {
+            UnsafeNativeMethods.mp_StatusOrPoller__value(MpPtr, out var pollerPtr).Assert();
+            Dispose();
+
+            return new OutputStreamPoller<T>(pollerPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Framework/Timestamp.cs
@@ -1,0 +1,137 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Framework
+{
+    public class Timestamp : MpResourceHandle, IEquatable<Timestamp>
+    {
+        public Timestamp(IntPtr ptr) : base(ptr) { }
+
+        public Timestamp(long value) : base()
+        {
+            UnsafeNativeMethods.mp_Timestamp__l(value, out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_Timestamp__delete(Ptr);
+
+        #region IEquatable<Timestamp>
+        public bool Equals(Timestamp? other) => other != null && Microseconds() == other.Microseconds();
+
+        public override bool Equals(object? obj)
+        {
+            var timestampObj = obj == null ? null : obj as Timestamp;
+
+            return timestampObj != null && Equals(timestampObj);
+        }
+
+        public static bool operator ==(Timestamp? x, Timestamp? y)
+            => x is null || y is null ? Equals(x, y) : x.Equals(y);
+
+        public static bool operator !=(Timestamp? x, Timestamp? y)
+            => x is null || y is null ? !Equals(x, y) : !x.Equals(y);
+
+        public override int GetHashCode() => Microseconds().GetHashCode();
+        #endregion
+
+        public long Value() => SafeNativeMethods.mp_Timestamp__Value(MpPtr);
+
+        public double Seconds() => SafeNativeMethods.mp_Timestamp__Seconds(MpPtr);
+
+        public long Microseconds() => SafeNativeMethods.mp_Timestamp__Microseconds(MpPtr);
+
+        public bool IsSpecialValue() => SafeNativeMethods.mp_Timestamp__IsSpecialValue(MpPtr);
+
+        public bool IsRangeValue() => SafeNativeMethods.mp_Timestamp__IsRangeValue(MpPtr);
+
+        public bool IsAllowedInStream() => SafeNativeMethods.mp_Timestamp__IsAllowedInStream(MpPtr);
+
+        public string? DebugString() => MarshalStringFromNative(UnsafeNativeMethods.mp_Timestamp__DebugString);
+
+        public Timestamp NextAllowedInStream()
+        {
+            UnsafeNativeMethods.mp_Timestamp__NextAllowedInStream(MpPtr, out var nextPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Timestamp(nextPtr);
+        }
+
+        public Timestamp PreviousAllowedInStream()
+        {
+            UnsafeNativeMethods.mp_Timestamp__PreviousAllowedInStream(MpPtr, out var prevPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new Timestamp(prevPtr);
+        }
+
+        public static Timestamp FromSeconds(double seconds)
+        {
+            UnsafeNativeMethods.mp_Timestamp_FromSeconds__d(seconds, out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        #region SpecialValues
+        public static Timestamp Unset()
+        {
+            UnsafeNativeMethods.mp_Timestamp_Unset(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp Unstarted()
+        {
+            UnsafeNativeMethods.mp_Timestamp_Unstarted(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp PreStream()
+        {
+            UnsafeNativeMethods.mp_Timestamp_PreStream(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp Min()
+        {
+            UnsafeNativeMethods.mp_Timestamp_Min(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp Max()
+        {
+            UnsafeNativeMethods.mp_Timestamp_Max(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp PostStream()
+        {
+            UnsafeNativeMethods.mp_Timestamp_PostStream(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp OneOverPostStream()
+        {
+            UnsafeNativeMethods.mp_Timestamp_OneOverPostStream(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+
+        public static Timestamp Done()
+        {
+            UnsafeNativeMethods.mp_Timestamp_Done(out var ptr).Assert();
+
+            return new Timestamp(ptr);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net/Framework/Tool/NameUtil.cs
+++ b/Mediapipe.Net/Framework/Tool/NameUtil.cs
@@ -1,0 +1,123 @@
+#pragma warning disable IDE0073
+// Copyright 2019 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Mediapipe.Net.Framework.Protobuf;
+
+namespace Mediapipe.Net.Framework.Tool
+{
+    /// <summary>
+    /// translated version of mediapipe/framework/tool/name_util.cc
+    /// <summary/>
+    public static partial class Tool
+    {
+        public static string GetUnusedNodeName(CalculatorGraphConfig config, string nodeNameBase)
+        {
+            var nodeNames = new HashSet<string>(config.Node.Select(node => node.Name).Where(name => name.Length > 0));
+
+            var candidate = nodeNameBase;
+            var iter = 1;
+
+            while (nodeNames.Contains(candidate))
+                candidate = $"{nodeNameBase}_{++iter:D2}";
+
+            return candidate;
+        }
+
+        public static string GetUnusedSidePacketName(CalculatorGraphConfig config, string inputSidePacketNameBase)
+        {
+            var inputSidePackets = new HashSet<string>(
+              config.Node.SelectMany(node => node.InputSidePacket)
+                .Select(sidePacket =>
+                {
+                    ParseTagIndexName(sidePacket, out var tag, out var index, out var name);
+                    return name;
+                }));
+
+            var candidate = inputSidePacketNameBase;
+            var iter = 1;
+
+            while (inputSidePackets.Contains(candidate))
+            {
+                candidate = $"{inputSidePacketNameBase}_{++iter:D2}";
+            }
+
+            return candidate;
+        }
+
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   Thrown when <paramref name="nodeId" /> is invalid
+        /// </exception>
+        public static string CanonicalNodeName(CalculatorGraphConfig graphConfig, int nodeId)
+        {
+            var nodeConfig = graphConfig.Node[nodeId];
+            var nodeName = nodeConfig.Name.Length == 0 ? nodeConfig.Calculator : nodeConfig.Name;
+
+            var nodesWithSameName = graphConfig.Node
+              .Select((node, i) => (node.Name.Length == 0 ? node.Calculator : node.Name, i))
+              .Where(pair => pair.Item1 == nodeName);
+
+            if (nodesWithSameName.Count() <= 1)
+            {
+                return nodeName;
+            }
+
+            var seq = nodesWithSameName.Count(pair => pair.i <= nodeId);
+            return $"{nodeName}_{seq}";
+        }
+
+        /// <exception cref="ArgumentException">
+        ///   Thrown when the format of <paramref cref="stream" /> is invalid
+        /// </exception>
+        public static string ParseNameFromStream(string stream)
+        {
+            ParseTagIndexName(stream, out var _, out var _, out var name);
+            return name;
+        }
+
+        /// <exception cref="ArgumentException">
+        ///   Thrown when the format of <paramref cref="tagIndex" /> is invalid
+        /// </exception>
+        public static (string, int) ParseTagIndex(string tagIndex)
+        {
+            ParseTagIndex(tagIndex, out var tag, out var index);
+            return (tag, index);
+        }
+
+        /// <exception cref="ArgumentException">
+        ///   Thrown when the format of <paramref cref="stream" /> is invalid
+        /// </exception>
+        public static (string, int) ParseTagIndexFromStream(string stream)
+        {
+            ParseTagIndexName(stream, out var tag, out var index, out var _);
+            return (tag, index);
+        }
+
+        public static string CatTag(string tag, int index)
+        {
+            var colonIndex = index <= 0 || tag.Length == 0 ? "" : $":{index}";
+            return $"{tag}{colonIndex}";
+        }
+
+        public static string CatStream((string, int) tagIndex, string name)
+        {
+            var tag = CatTag(tagIndex.Item1, tagIndex.Item2);
+
+            return tag.Length == 0 ? name : $"{tag}:{name}";
+        }
+    }
+}
+#pragma warning restore IDE0073

--- a/Mediapipe.Net/Framework/Tool/ValidateName.cs
+++ b/Mediapipe.Net/Framework/Tool/ValidateName.cs
@@ -1,0 +1,176 @@
+#pragma warning disable IDE0073
+// Copyright 2019 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Mediapipe.Net.Framework.Tool
+{
+    /// <summary>
+    ///   translated version of mediapipe/framework/tool/validate_name.cc
+    /// <summary/>
+    internal static partial class Internal
+    {
+        public const int MaxCollectionItemId = 10000;
+    }
+
+    public static partial class Tool
+    {
+        private const string name_regex = "[a-z_][a-z0-9_]*";
+        private const string number_regex = "(0|[1-9][0-9]*)";
+        private const string tag_regex = "[A-Z_][A-Z0-9_]*";
+        private static readonly string tagAndNameRegex = $"({tag_regex}:)?{name_regex}";
+        private static readonly string tagIndexNameRegex = $"({tag_regex}:({number_regex}:)?)?{name_regex}";
+        private static readonly string tagIndexRegex = $"({tag_regex})?(:{number_regex})?";
+
+        public static void ValidateName(string name)
+        {
+            if (name.Length > 0 && new Regex($"^{name_regex}$").IsMatch(name))
+                return;
+
+            throw new ArgumentException($"Name \"{name}\" does not match \"{name_regex}\".");
+        }
+
+        public static void ValidateNumber(string number)
+        {
+            if (number.Length > 0 && new Regex($"^{number_regex}$").IsMatch(number))
+                return;
+
+            throw new ArgumentException($"Number \"{number}\" does not match \"{number_regex}\".");
+        }
+
+        public static void ValidateTag(string tag)
+        {
+            if (tag.Length > 0 && new Regex($"^{tag_regex}$").IsMatch(tag))
+                return;
+
+            throw new ArgumentException($"Tag \"{tag}\" does not match \"{tag_regex}\".");
+        }
+
+        public static void ParseTagAndName(string tagAndName, out string tag, out string name)
+        {
+            var nameIndex = -1;
+            var v = tagAndName.Split(':');
+
+            try
+            {
+                if (v.Length == 1)
+                {
+                    ValidateName(v[0]);
+                    nameIndex = 0;
+                }
+                else if (v.Length == 2)
+                {
+                    ValidateTag(v[0]);
+                    ValidateName(v[1]);
+                    nameIndex = 1;
+                }
+
+                // TODO: what do we put inside of this ArgumentException?
+                if (nameIndex == -1)
+                    throw new ArgumentException();
+            }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException($"\"tag and name\" is invalid, \"{tagAndName}\" does not match \"{tagAndNameRegex}\" (examples: \"TAG:name\", \"longer_name\").");
+            }
+
+            tag = nameIndex == 1 ? v[0] : "";
+            name = v[nameIndex];
+        }
+
+        public static void ParseTagIndexName(string tagIndexName, out string tag, out int index, out string name)
+        {
+            var nameIndex = -1;
+            var theIndex = 0;
+            var v = tagIndexName.Split(':');
+
+            try
+            {
+                if (v.Length == 1)
+                {
+                    ValidateName(v[0]);
+                    theIndex = -1;
+                    nameIndex = 0;
+                }
+                else if (v.Length == 2)
+                {
+                    ValidateTag(v[0]);
+                    ValidateName(v[1]);
+                    nameIndex = 1;
+                }
+                else if (v.Length == 3)
+                {
+                    ValidateTag(v[0]);
+                    ValidateNumber(v[1]);
+
+                    theIndex = int.TryParse(v[1], out var result) && result <= Internal.MaxCollectionItemId ? result : throw new ArgumentException();
+                    ValidateName(v[2]);
+                    nameIndex = 2;
+                }
+
+                if (nameIndex == -1)
+                    throw new ArgumentException();
+            }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException($"TAG:index:name is invalid, \"{tagIndexName}\" does not match \"{tagIndexNameRegex}\" (examples: \"TAG:name\", \"VIDEO:2:name_b\", \"longer_name\").");
+            }
+
+            tag = nameIndex != 0 ? v[0] : "";
+            index = theIndex;
+            name = v[nameIndex];
+        }
+
+        public static void ParseTagIndex(string tagIndex, out string tag, out int index)
+        {
+            var theIndex = -1;
+            var v = tagIndex.Split(':');
+
+            try
+            {
+                if (v.Length == 1)
+                {
+                    if (v[0].Length != 0)
+                    {
+                        ValidateTag(v[0]);
+                    }
+                    theIndex = 0;
+                }
+                else if (v.Length == 2)
+                {
+                    if (v[0].Length != 0)
+                    {
+                        ValidateTag(v[0]);
+                    }
+                    ValidateNumber(v[1]);
+
+                    theIndex = int.TryParse(v[1], out var result) && result <= Internal.MaxCollectionItemId ? result : throw new ArgumentException();
+                }
+
+                if (theIndex == -1)
+                    throw new ArgumentException();
+            }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException($"TAG:index is invalid, \"{tagIndex}\" does not match \"{tagIndexRegex}\" (examples: \"TAG\", \"VIDEO:2\").");
+            }
+
+            tag = v[0];
+            index = theIndex;
+        }
+    }
+}
+#pragma warning restore IDE0073

--- a/Mediapipe.Net/Gpu/Egl.cs
+++ b/Mediapipe.Net/Gpu/Egl.cs
@@ -1,0 +1,16 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Runtime.Versioning;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Gpu
+{
+    [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
+    public class Egl
+    {
+        public static IntPtr GetCurrentContext() => SafeNativeMethods.eglGetCurrentContext();
+    }
+}

--- a/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
@@ -1,0 +1,139 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Format;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Gpu
+{
+    public class GlCalculatorHelper : MpResourceHandle
+    {
+        public delegate IntPtr NativeGlStatusFunction();
+        public delegate Status GlStatusFunction();
+
+        public GlCalculatorHelper() : base()
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__(out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_GlCalculatorHelper__delete(Ptr);
+
+        public void InitializeForTest(GpuResources gpuResources)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__InitializeForTest__Pgr(MpPtr, gpuResources.MpPtr).Assert();
+
+            GC.KeepAlive(gpuResources);
+            GC.KeepAlive(this);
+        }
+
+        /// <param name="nativeGlStatusFunction">
+        ///   Function that is run in Gl Context.
+        ///   Make sure that this function doesn't throw exceptions and won't be GCed.
+        /// </param>
+        public Status RunInGlContext(NativeGlStatusFunction nativeGlStatusFunction)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__RunInGlContext__PF(MpPtr, nativeGlStatusFunction, out var statusPtr).Assert();
+            GC.KeepAlive(this);
+
+            return new Status(statusPtr);
+        }
+
+        public Status RunInGlContext(GlStatusFunction glStatusFunc)
+        {
+            Status? tmpStatus = null;
+
+            NativeGlStatusFunction nativeGlStatusFunc = () =>
+            {
+                try
+                {
+                    tmpStatus = glStatusFunc();
+                }
+                catch (Exception e)
+                {
+                    tmpStatus = Status.FailedPrecondition(e.ToString());
+                }
+                return tmpStatus.MpPtr;
+            };
+
+            var nativeGlStatusFuncHandle = GCHandle.Alloc(nativeGlStatusFunc, GCHandleType.Pinned);
+            var status = RunInGlContext(nativeGlStatusFunc);
+            nativeGlStatusFuncHandle.Free();
+
+            if (tmpStatus != null)
+                tmpStatus.Dispose();
+            return status;
+        }
+
+        public GlTexture CreateSourceTexture(ImageFrame imageFrame)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__CreateSourceTexture__Rif(MpPtr, imageFrame.MpPtr, out var texturePtr).Assert();
+
+            GC.KeepAlive(this);
+            GC.KeepAlive(imageFrame);
+            return new GlTexture(texturePtr);
+        }
+
+        public GlTexture CreateSourceTexture(GpuBuffer gpuBuffer)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__CreateSourceTexture__Rgb(MpPtr, gpuBuffer.MpPtr, out var texturePtr).Assert();
+
+            GC.KeepAlive(this);
+            GC.KeepAlive(gpuBuffer);
+            return new GlTexture(texturePtr);
+        }
+
+        [SupportedOSPlatform("IOS")]
+        public GlTexture CreateSourceTexture(GpuBuffer gpuBuffer, int plane)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__CreateSourceTexture__Rgb_i(MpPtr, gpuBuffer.MpPtr, plane, out var texturePtr).Assert();
+
+            GC.KeepAlive(this);
+            GC.KeepAlive(gpuBuffer);
+            return new GlTexture(texturePtr);
+        }
+
+        public GlTexture CreateDestinationTexture(int width, int height, GpuBufferFormat format)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__CreateDestinationTexture__i_i_ui(MpPtr, width, height, format, out var texturePtr).Assert();
+
+            GC.KeepAlive(this);
+            return new GlTexture(texturePtr);
+        }
+
+        public GlTexture CreateDestinationTexture(GpuBuffer gpuBuffer)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__CreateDestinationTexture__Rgb(MpPtr, gpuBuffer.MpPtr, out var texturePtr).Assert();
+
+            GC.KeepAlive(this);
+            GC.KeepAlive(gpuBuffer);
+            return new GlTexture(texturePtr);
+        }
+
+        public uint Framebuffer => SafeNativeMethods.mp_GlCalculatorHelper__framebuffer(MpPtr);
+
+        public void BindFramebuffer(GlTexture glTexture)
+        {
+            UnsafeNativeMethods.mp_GlCalculatorHelper__BindFrameBuffer__Rtexture(MpPtr, glTexture.MpPtr).Assert();
+
+            GC.KeepAlive(glTexture);
+            GC.KeepAlive(this);
+        }
+
+        public GlContext GetGlContext()
+        {
+            var glContextPtr = SafeNativeMethods.mp_GlCalculatorHelper__GetGlContext(MpPtr);
+
+            GC.KeepAlive(this);
+            return new GlContext(glContextPtr, false);
+        }
+
+        public bool Initialized() => SafeNativeMethods.mp_GlCalculatorHelper__Initialized(MpPtr);
+    }
+}

--- a/Mediapipe.Net/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Gpu/GlTexture.cs
@@ -1,0 +1,45 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Gpu
+{
+    public class GlTexture : MpResourceHandle
+    {
+        public GlTexture() : base()
+        {
+            UnsafeNativeMethods.mp_GlTexture__(out var ptr).Assert();
+            Ptr = ptr;
+        }
+
+        public GlTexture(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_GlTexture__delete(Ptr);
+
+        public int Width => SafeNativeMethods.mp_GlTexture__width(MpPtr);
+
+        public int Height => SafeNativeMethods.mp_GlTexture__height(MpPtr);
+
+        public uint Target => SafeNativeMethods.mp_GlTexture__target(MpPtr);
+
+        public uint Name => SafeNativeMethods.mp_GlTexture__name(MpPtr);
+
+        public void Release()
+        {
+            UnsafeNativeMethods.mp_GlTexture__Release(MpPtr).Assert();
+            GC.KeepAlive(this);
+        }
+
+        public GpuBuffer GetGpuBufferFrame()
+        {
+            UnsafeNativeMethods.mp_GlTexture__GetGpuBufferFrame(MpPtr, out var gpuBufferPtr).Assert();
+
+            GC.KeepAlive(this);
+            return new GpuBuffer(gpuBufferPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Gpu/GpuBuffer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Runtime.Versioning;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Gpu
+{
+    public class GpuBuffer : MpResourceHandle
+    {
+        public GpuBuffer(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+        [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
+        public GpuBuffer(GlTextureBuffer glTextureBuffer) : base()
+        {
+            UnsafeNativeMethods.mp_GpuBuffer__PSgtb(glTextureBuffer.SharedPtr, out var ptr).Assert();
+            glTextureBuffer.Dispose(); // respect move semantics
+            Ptr = ptr;
+        }
+
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_GpuBuffer__delete(Ptr);
+
+        [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
+        public GlTextureBuffer GetGlTextureBuffer()
+            => new GlTextureBuffer(SafeNativeMethods.mp_GpuBuffer__GetGlTextureBufferSharedPtr(MpPtr), false);
+
+        public GpuBufferFormat Format() => SafeNativeMethods.mp_GpuBuffer__format(MpPtr);
+
+        public int Width() => SafeNativeMethods.mp_GpuBuffer__width(MpPtr);
+
+        public int Height() => SafeNativeMethods.mp_GpuBuffer__height(MpPtr);
+    }
+}

--- a/Mediapipe.Net/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Gpu/GpuResources.cs
@@ -1,0 +1,69 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Runtime.Versioning;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Gpu
+{
+    public class GpuResources : MpResourceHandle
+    {
+        private SharedPtrHandle? sharedPtrHandle;
+
+        /// <param name="ptr">Shared pointer of mediapipe::GpuResources</param>
+        public GpuResources(IntPtr ptr) : base()
+        {
+            sharedPtrHandle = new SharedGpuResourcesPtr(ptr);
+            Ptr = sharedPtrHandle.Get();
+        }
+
+        protected override void DisposeManaged()
+        {
+            if (sharedPtrHandle != null)
+            {
+                sharedPtrHandle.Dispose();
+                sharedPtrHandle = null;
+            }
+            base.DisposeManaged();
+        }
+
+        protected override void DeleteMpPtr()
+        {
+            // Do nothing
+        }
+
+        public IntPtr SharedPtr => sharedPtrHandle == null ? IntPtr.Zero : sharedPtrHandle.MpPtr;
+
+        public static StatusOrGpuResources Create()
+        {
+            UnsafeNativeMethods.mp_GpuResources_Create(out var statusOrGpuResourcesPtr).Assert();
+
+            return new StatusOrGpuResources(statusOrGpuResourcesPtr);
+        }
+
+        public static StatusOrGpuResources Create(IntPtr externalContext)
+        {
+            UnsafeNativeMethods.mp_GpuResources_Create__Pv(externalContext, out var statusOrGpuResourcesPtr).Assert();
+
+            return new StatusOrGpuResources(statusOrGpuResourcesPtr);
+        }
+
+        [SupportedOSPlatform("IOS")]
+        public IntPtr IosGpuData => SafeNativeMethods.mp_GpuResources__ios_gpu_data(MpPtr);
+
+        private class SharedGpuResourcesPtr : SharedPtrHandle
+        {
+            public SharedGpuResourcesPtr(IntPtr ptr) : base(ptr) { }
+
+            protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_SharedGpuResources__delete(Ptr);
+
+            public override IntPtr Get() => SafeNativeMethods.mp_SharedGpuResources__get(MpPtr);
+
+            public override void Reset() => UnsafeNativeMethods.mp_SharedGpuResources__reset(MpPtr);
+        }
+    }
+}

--- a/Mediapipe.Net/Mediapipe.Net.csproj
+++ b/Mediapipe.Net/Mediapipe.Net.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="Google.Protobuf" Version="3.19.3" />
+    <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
   </ItemGroup>
 
 </Project>

--- a/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
@@ -2,23 +2,19 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
+using Mediapipe.Net.Util;
 
 namespace Mediapipe.Net.Native
 {
     internal partial class SafeNativeMethods : NativeMethods
     {
-        // TODO: Make it be a member of ResourceManager
-        public delegate bool ResourceProvider(string path, IntPtr output);
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp__SetCustomGlobalResourceProvider__P(
-            [MarshalAs(UnmanagedType.FunctionPtr)] ResourceProvider provider);
+            [MarshalAs(UnmanagedType.FunctionPtr)] ResourceManager.ResourceProvider provider);
 
-        // TODO: Make it be a member of ResourceManager
-        public delegate string PathResolver(string path);
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp__SetCustomGlobalPathResolver__P(
-            [MarshalAs(UnmanagedType.FunctionPtr)] PathResolver resolver);
+            [MarshalAs(UnmanagedType.FunctionPtr)] ResourceManager.PathResolver resolver);
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.External;
+using Mediapipe.Net.Framework;
 
 namespace Mediapipe.Net.Native
 {
@@ -32,12 +33,9 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__Config(IntPtr graph, out SerializedProto serializedProto);
 
-        // TODO: Make it be a member of CalculatorGraph
-        public delegate IntPtr NativePacketCallback(IntPtr graphPtr, IntPtr packetPtr);
-
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(IntPtr graph, string streamName,
-            [MarshalAs(UnmanagedType.FunctionPtr)] NativePacketCallback packetCallback,
+            [MarshalAs(UnmanagedType.FunctionPtr)] CalculatorGraph.NativePacketCallback packetCallback,
             [MarshalAs(UnmanagedType.I1)] bool observeTimestampBounds, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -21,10 +21,9 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp_GlCalculatorHelper__InitializeForTest__Pgr(IntPtr glCalculatorHelper, IntPtr gpuResources);
 
         // TODO: Make it ba a member of GlCalculatorHelper
-        public delegate IntPtr NativeGlStatusFunction();
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__RunInGlContext__PF(
-            IntPtr glCalculatorHelper, [MarshalAs(UnmanagedType.FunctionPtr)] NativeGlStatusFunction glFunc, out IntPtr status);
+            IntPtr glCalculatorHelper, [MarshalAs(UnmanagedType.FunctionPtr)] GlCalculatorHelper.NativeGlStatusFunction glFunc, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateSourceTexture__Rif(

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -1,0 +1,75 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections;
+using System.IO;
+using Mediapipe.Net.Native;
+
+namespace Mediapipe.Net.Util
+{
+    /// <summary>
+    /// Class to manage assets that MediaPipe accesses.
+    /// </summary>
+    /// <remarks>
+    /// There must not be more than one instance at the same time.
+    /// </remarks>
+    public abstract class ResourceManager
+    {
+        public delegate string PathResolver(string path);
+        public abstract PathResolver ResolvePath { get; }
+        public delegate bool ResourceProvider(string path, IntPtr output);
+        public abstract ResourceProvider ProvideResource { get; }
+
+        private static readonly object initLock = new object();
+        private static bool isInitialized = false;
+
+        public ResourceManager()
+        {
+            lock (initLock)
+            {
+                if (isInitialized)
+                    throw new InvalidOperationException("ResourceManager can be initialized only once");
+
+                SafeNativeMethods.mp__SetCustomGlobalPathResolver__P(ResolvePath);
+                SafeNativeMethods.mp__SetCustomGlobalResourceProvider__P(ProvideResource);
+                isInitialized = true;
+            }
+        }
+
+        /// <param name="name">Asset name</param>
+        /// <returns>
+        ///   Returns true if <paramref name="name" /> is already prepared (saved locally on the device).
+        /// </returns>
+        public abstract bool IsPrepared(string name);
+
+        /// <summary>
+        ///   Saves <paramref name="name" /> as <paramref name="uniqueKey" /> asynchronously.
+        /// </summary>
+        /// <param name="overwrite">
+        ///   Specifies whether <paramref name="uniqueKey" /> will be overwritten if it already exists.
+        /// </param>
+        public abstract IEnumerator PrepareAssetAsync(string name, string uniqueKey, bool overwrite = true);
+
+        public IEnumerator PrepareAssetAsync(string name, bool overwrite = true)
+            => PrepareAssetAsync(name, name, overwrite);
+
+        protected static string GetAssetNameFromPath(string assetPath)
+        {
+            var assetName = Path.GetFileNameWithoutExtension(assetPath);
+            var extension = Path.GetExtension(assetPath);
+
+            switch (extension)
+            {
+                case ".binarypb":
+                case ".tflite":
+                    return $"{assetName}.bytes";
+                case ".pbtxt":
+                    return $"{assetName}.txt";
+                default:
+                    return $"{assetName}{extension}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR ports all remaining bindings from MediaPipeUnityPlugin.

Several things to note:
- I replaced the only present Unity-specific `NativeArray` with `byte*`. We benefit from .NET 6's `NativeMemory` but I just don't know if there's a better type for a standard unmanaged array in that context.
- Since we use nullables, I've had a lot of head-scratching trying to figure out if something should be nullable or not. We'll very likely face problems in tests about this.
- The only changes that I made are namespace reorganization and syntax formatting. I didn't turn functions into properties or changed arguments in the slightest, though it might definitely be something we want to do in the future.
- Also in the future, we'll want to find a way to not call `Activator` for `Packet`-related generic typing.