### PR TITLE
Port all tests from MediaPipeUnityPlugin

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,20 +1,23 @@
 name: Report
 on:
-  workflow_call:
-    inputs:
-      name:
-        required: true
-        type: string
+  workflow_run:
+    workflows: [ 'Test' ]
+    branches:
+      - '*'
+    types:
+      - completed
 
 jobs:
   report:
     name: Report
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
       - name: Report
-        uses: dorny/test-reporter@v1.4.2
+        uses: dorny/test-reporter@v1
         with:
-          artifact: TestResults-${{ inputs.name }}
-          name: Test Results
+          artifact: /TestResults-(.*)/
+          name: Test Results ($1)
           path: "*.trx"
           reporter: dotnet-trx
+          fail-on-error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
       - name: Setup tmate session
+        if: $${{ failed() }}
         uses: mxschmitt/action-tmate@v3
 
       - name: Upload test artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,13 @@ jobs:
       - name: Build MediaPipe.NET
         run: dotnet build -c Debug ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }} --self-contained
 
-      - name: Test MediaPipe.NET
+      # Ignore SignalAbort tests on Windows
+      - name: Test MediaPipe.NET (Windows)
+        if: ${{ matrix.os.name == 'Windows' }}
+        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly&TestCategory!=SignalAbort" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
+
+      - name: Test MediaPipe.NET (*nix)
+        if: ${{ matrix.os.name != 'Windows' }}
         run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
       - name: Setup tmate session

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test MediaPipe.NET (*nix)
         if: ${{ matrix.os.name != 'Windows' }}
-        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
+        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=${{ env.TEST_PROJECT_NAME }}/TestResults-${{ matrix.os.name }}.trx"
 
       - name: Setup tmate session
         if: ${{ failure() }}
@@ -56,4 +56,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: TestResults-${{ matrix.os.name }}
-          path: ${{ env.TEST_PROJECT_NAME }}/TestResults/*.trx
+          path: ${{ env.TEST_PROJECT_NAME }}/TestResults-*.trx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os:
           - { name: Windows, runner: windows-latest, runtime: win-x64 }
-          - { name: MacOS, runner: macos-latest, runtime: osx-x64 }
+          # - { name: MacOS, runner: macos-latest, runtime: osx-x64 }
           - { name: Linux, runner: ubuntu-latest, runtime: linux-x64 }
     steps:
       - name: Checkout
@@ -34,10 +34,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'
-
-      - name: Setup FFmpeg (MacOS)
-        if: ${{ matrix.os.name == 'MacOS' }}
-        run: brew install ffmpeg
 
       - name: Build MediaPipe.NET
         run: dotnet build -c Debug ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }} --self-contained

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
       - name: Setup tmate session
-        if: $${{ failure() }}
+        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
       - name: Upload test artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
@@ -43,6 +40,9 @@ jobs:
 
       - name: Test MediaPipe.NET
         run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Upload test artifact
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test MediaPipe.NET (*nix)
         if: ${{ matrix.os.name != 'Windows' }}
-        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=${{ env.TEST_PROJECT_NAME }}/TestResults-${{ matrix.os.name }}.trx"
+        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
       - name: Setup tmate session
         if: ${{ failure() }}
@@ -56,4 +56,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: TestResults-${{ matrix.os.name }}
-          path: ${{ env.TEST_PROJECT_NAME }}/TestResults-*.trx
+          path: ${{ matrix.os.runtime }}/*.trx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
+      - name: Setup FFmpeg (MacOS)
+        if: ${{ matrix.os.name == 'MacOS' }}
+        run: brew install ffmpeg
+
       - name: Build MediaPipe.NET
         run: dotnet build -c Debug ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }} --self-contained
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
           dotnet-version: '6.0.x'
 
       - name: Build MediaPipe.NET
-        run: dotnet build -c Debug ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }}
+        run: dotnet build -c Debug ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }} --self-contained
 
       - name: Test MediaPipe.NET
-        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
+        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
       - name: Upload test artifact
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} -r ${{ matrix.os.runtime }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
       - name: Setup tmate session
-        if: $${{ failed() }}
+        if: $${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
       - name: Upload test artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,42 +1,49 @@
 name: Test
 on:
-  workflow_call:
-    inputs:
-      name:
-        required: true
-        type: string
-      path:
-        required: true
-        type: string
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+
+env:
+  PROJECT_NAME: Mediapipe.Net
+  TEST_PROJECT_NAME: Mediapipe.Net.Tests
 
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { name: Windows, runner: windows-latest, runtime: win-x64 }
+          - { name: MacOS, runner: macos-latest, runtime: osx-x64 }
+          - { name: Linux, runner: ubuntu-latest, runtime: linux-x64 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install .NET
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'
 
-      - name: Lint
-        uses: github/super-linter@v4
-        env:
-          SUPPRESS_POSSUM: true
-          VALIDATE_CSHARP: true
-          VALIDATE_EDITORCONFIG: true
-          VALIDATE_ALL_CODEBASE: false
+      - name: Build MediaPipe.NET
+        run: dotnet build -c Debug ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }}
 
-      - name: Test
-        run: dotnet test sbtw-desktop.slnf --logger "trx;LogFileName=${{ inputs.name }}.trx"
+      - name: Test MediaPipe.NET
+        run: dotnet test -c Debug ${{ env.TEST_PROJECT_NAME }} --filter "TestCategory!=GpuOnly" --logger "trx;LogFileName=TestResults-${{ matrix.os.name }}.trx"
 
-      - name: Upload Results
-        uses: actions/upload-artifact@v2
+      - name: Upload test artifact
         if: ${{ always() }}
+        uses: actions/upload-artifact@v2
         with:
-          name: ${{ inputs.name }}
-          path: ${{ github.workspace }}/${{ inputs.path }}/TestResults/TestResults-${{ inputs.name }}.trx
-
+          name: TestResults-${{ matrix.os.name }}
+          path: ${{ env.TEST_PROJECT_NAME }}/TestResults/*.trx

--- a/Mediapipe.Net.Tests/Framework/CalculatorGraphTest.cs
+++ b/Mediapipe.Net.Tests/Framework/CalculatorGraphTest.cs
@@ -48,7 +48,7 @@ output_stream: ""out""
         }
         #endregion
 
-        #region #IsDisposed
+        #region IsDisposed
         [Test]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -66,7 +66,7 @@ output_stream: ""out""
         }
         #endregion
 
-        #region #Initialize
+        #region Initialize
         [Test]
         public void Initialize_ShouldReturnOk_When_CalledWithConfig_And_ConfigIsNotSet()
         {
@@ -116,7 +116,7 @@ output_stream: ""out""
         }
         #endregion
 
-        #region lifecycle
+        #region Lifecycle
         [Test]
         public void LifecycleMethods_ShouldControlGraphLifeCycle()
         {

--- a/Mediapipe.Net.Tests/Framework/CalculatorGraphTest.cs
+++ b/Mediapipe.Net.Tests/Framework/CalculatorGraphTest.cs
@@ -1,0 +1,144 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Framework.Protobuf;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework
+{
+    public class CalculatorGraphTest
+    {
+        // TODO: honestly this would be way better as the content of a file.
+        private const string valid_config_text = @"node {
+  calculator: ""PassThroughCalculator""
+  input_stream: ""in""
+  output_stream: ""out1""
+}
+node {
+  calculator: ""PassThroughCalculator""
+  input_stream: ""out1""
+  output_stream: ""out""
+}
+input_stream: ""in""
+output_stream: ""out""
+";
+
+        #region Constructor
+        [Test]
+        public void Ctor_ShouldInstantiateCalculatorGraph_When_CalledWithNoArguments()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var graph = new CalculatorGraph();
+                graph.Dispose();
+            });
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiateCalculatorGraph_When_CalledWithConfigText()
+        {
+            using var graph = new CalculatorGraph(valid_config_text);
+            var config = graph.Config();
+            Assert.AreEqual(config.InputStream[0], "in");
+            Assert.AreEqual(config.OutputStream[0], "out");
+        }
+        #endregion
+
+        #region #IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var graph = new CalculatorGraph();
+            Assert.False(graph.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var graph = new CalculatorGraph();
+            graph.Dispose();
+
+            Assert.True(graph.IsDisposed);
+        }
+        #endregion
+
+        #region #Initialize
+        [Test]
+        public void Initialize_ShouldReturnOk_When_CalledWithConfig_And_ConfigIsNotSet()
+        {
+            using var graph = new CalculatorGraph();
+            using (var status = graph.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(valid_config_text)))
+            {
+                Assert.True(status.Ok());
+            }
+
+            var config = graph.Config();
+            Assert.AreEqual(config.InputStream[0], "in");
+            Assert.AreEqual(config.OutputStream[0], "out");
+        }
+
+        [Test]
+        public void Initialize_ShouldReturnInternalError_When_CalledWithConfig_And_ConfigIsSet()
+        {
+            using var graph = new CalculatorGraph(valid_config_text);
+            using var status = graph.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(valid_config_text));
+            Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
+        }
+
+        [Test]
+        public void Initialize_ShouldReturnOk_When_CalledWithConfigAndSidePacket_And_ConfigIsNotSet()
+        {
+            using var sidePacket = new SidePacket();
+            sidePacket.Emplace("flag", new BoolPacket(true));
+
+            using var graph = new CalculatorGraph();
+            var config = CalculatorGraphConfig.Parser.ParseFromTextFormat(valid_config_text);
+
+            using var status = graph.Initialize(config, sidePacket);
+            Assert.True(status.Ok());
+        }
+
+        [Test]
+        public void Initialize_ShouldReturnInternalError_When_CalledWithConfigAndSidePacket_And_ConfigIsSet()
+        {
+            using var sidePacket = new SidePacket();
+            sidePacket.Emplace("flag", new BoolPacket(true));
+
+            using var graph = new CalculatorGraph(valid_config_text);
+            var config = CalculatorGraphConfig.Parser.ParseFromTextFormat(valid_config_text);
+
+            using var status = graph.Initialize(config, sidePacket);
+            Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
+        }
+        #endregion
+
+        #region lifecycle
+        [Test]
+        public void LifecycleMethods_ShouldControlGraphLifeCycle()
+        {
+            using var graph = new CalculatorGraph(valid_config_text);
+            Assert.True(graph.StartRun().Ok());
+            Assert.False(graph.GraphInputStreamsClosed());
+
+            Assert.True(graph.WaitUntilIdle().Ok());
+            Assert.True(graph.CloseAllPacketSources().Ok());
+            Assert.True(graph.GraphInputStreamsClosed());
+            Assert.True(graph.WaitUntilDone().Ok());
+            Assert.False(graph.HasError());
+        }
+
+        [Test]
+        public void Cancel_ShouldCancelGraph()
+        {
+            using var graph = new CalculatorGraph(valid_config_text);
+            Assert.True(graph.StartRun().Ok());
+            graph.Cancel();
+            Assert.AreEqual(graph.WaitUntilDone().Code(), Status.StatusCode.Cancelled);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -83,7 +83,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             }
         }
 
-        [Test]
+        [Test, SignalAbort]
         public void Ctor_ShouldThrowMediaPipeException_When_CalledWithInvalidArgument()
         {
 #pragma warning disable IDE0058
@@ -143,7 +143,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
         }
 
-        [Test]
+        [Test, SignalAbort]
         public void CopyToByteBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
         {
             using var imageFrame = new ImageFrame(ImageFormat.Gray8, 10, 10);
@@ -162,7 +162,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
         }
 
-        [Test]
+        [Test, SignalAbort]
         public void CopyToUshortBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
         {
             using var imageFrame = new ImageFrame(ImageFormat.Gray16, 10, 10);
@@ -181,7 +181,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.IsEmpty(normalBuffer.Where((x, i) => Math.Abs(x - largeBuffer[i]) > 1e-9));
         }
 
-        [Test]
+        [Test, SignalAbort]
         public void CopyToFloatBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
         {
             using var imageFrame = new ImageFrame(ImageFormat.Vec32f1, 10, 10);

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -1,0 +1,194 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Linq;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Format;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Format
+{
+    public class ImageFrameTest
+    {
+        #region Constructor
+        [Test, SignalAbort]
+        public void Ctor_ShouldInstantiateImageFrame_When_CalledWithNoArguments()
+        {
+            using var imageFrame = new ImageFrame();
+#pragma warning disable IDE0058
+            Assert.AreEqual(imageFrame.Format(), ImageFormat.Unknown);
+            Assert.AreEqual(imageFrame.Width(), 0);
+            Assert.AreEqual(imageFrame.Height(), 0);
+            Assert.Throws<FormatException>(() => { imageFrame.ChannelSize(); });
+            Assert.Throws<FormatException>(() => { imageFrame.NumberOfChannels(); });
+            Assert.Throws<FormatException>(() => { imageFrame.ByteDepth(); });
+            Assert.AreEqual(imageFrame.WidthStep(), 0);
+            Assert.AreEqual(imageFrame.PixelDataSize(), 0);
+            Assert.Throws<FormatException>(() => { imageFrame.PixelDataSizeStoredContiguously(); });
+            Assert.True(imageFrame.IsEmpty());
+            Assert.False(imageFrame.IsContiguous());
+            Assert.False(imageFrame.IsAligned(16));
+            Assert.AreEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiateImageFrame_When_CalledWithFormat()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Sbgra, 640, 480);
+            Assert.AreEqual(imageFrame.Format(), ImageFormat.Sbgra);
+            Assert.AreEqual(imageFrame.Width(), 640);
+            Assert.AreEqual(imageFrame.Height(), 480);
+            Assert.AreEqual(imageFrame.ChannelSize(), 1);
+            Assert.AreEqual(imageFrame.NumberOfChannels(), 4);
+            Assert.AreEqual(imageFrame.ByteDepth(), 1);
+            Assert.AreEqual(imageFrame.WidthStep(), 640 * 4);
+            Assert.AreEqual(imageFrame.PixelDataSize(), 640 * 480 * 4);
+            Assert.AreEqual(imageFrame.PixelDataSizeStoredContiguously(), 640 * 480 * 4);
+            Assert.False(imageFrame.IsEmpty());
+            Assert.True(imageFrame.IsContiguous());
+            Assert.True(imageFrame.IsAligned(16));
+            Assert.AreNotEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiateImageFrame_When_CalledWithFormatAndAlignmentBoundary()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray8, 100, 100, 8);
+            Assert.AreEqual(imageFrame.Width(), 100);
+            Assert.AreEqual(imageFrame.NumberOfChannels(), 1);
+            Assert.AreEqual(imageFrame.WidthStep(), 104);
+        }
+
+        [Test]
+        unsafe public void Ctor_ShouldInstantiateImageFrame_When_CalledWithPixelData()
+        {
+            byte[] srcBytes = new byte[] {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+                16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            };
+            byte[] dupBytes = srcBytes.ToArray();
+
+            fixed (byte* pixelData = dupBytes)
+            {
+                using var imageFrame = new ImageFrame(ImageFormat.Sbgra, 4, 2, 16, pixelData);
+                Assert.AreEqual(imageFrame.Width(), 4);
+                Assert.AreEqual(imageFrame.Height(), 2);
+                Assert.False(imageFrame.IsEmpty());
+
+                var bytes = imageFrame.CopyToByteBuffer(32);
+                Assert.IsEmpty(bytes.Where((x, i) => x != srcBytes[i]));
+            }
+        }
+
+        [Test]
+        public void Ctor_ShouldThrowMediaPipeException_When_CalledWithInvalidArgument()
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<MediapipeException>(() => { new ImageFrame(ImageFormat.Sbgra, 640, 480, 0); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region #isDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var imageFrame = new ImageFrame();
+            Assert.False(imageFrame.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var imageFrame = new ImageFrame();
+            imageFrame.Dispose();
+
+            Assert.True(imageFrame.IsDisposed);
+        }
+        #endregion
+
+        #region #SetToZero
+        [Test]
+        public void SetToZero_ShouldSetZeroToAllBytes()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray8, 10, 10);
+            var origBytes = imageFrame.CopyToByteBuffer(100);
+
+            imageFrame.SetToZero();
+            var bytes = imageFrame.CopyToByteBuffer(100);
+            Assert.True(bytes.All((x) => x == 0));
+        }
+        #endregion
+
+        #region #SetAlignmentPaddingAreas
+        [Test]
+        public void SetAlignmentPaddingAreas_ShouldNotThrow()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray8, 10, 10, 16);
+            Assert.DoesNotThrow(() => { imageFrame.SetAlignmentPaddingAreas(); });
+        }
+        #endregion
+
+        #region CopyToBuffer
+        [Test]
+        public void CopyToByteBuffer_ShouldReturnByteArray_When_BufferSizeIsLargeEnough()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray8, 10, 10);
+            var normalBuffer = imageFrame.CopyToByteBuffer(100);
+            var largeBuffer = imageFrame.CopyToByteBuffer(120);
+
+            Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
+        }
+
+        [Test]
+        public void CopyToByteBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray8, 10, 10);
+#pragma warning disable IDE0058
+            Assert.Throws<MediapipeException>(() => { imageFrame.CopyToByteBuffer(99); });
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void CopyToUshortBuffer_ShouldReturnUshortArray_When_BufferSizeIsLargeEnough()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray16, 10, 10);
+            var normalBuffer = imageFrame.CopyToUshortBuffer(100);
+            var largeBuffer = imageFrame.CopyToUshortBuffer(120);
+
+            Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
+        }
+
+        [Test]
+        public void CopyToUshortBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Gray16, 10, 10);
+#pragma warning disable IDE0058
+            Assert.Throws<MediapipeException>(() => { imageFrame.CopyToUshortBuffer(99); });
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void CopyToFloatBuffer_ShouldReturnFloatArray_When_BufferSizeIsLargeEnough()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Vec32f1, 10, 10);
+            var normalBuffer = imageFrame.CopyToFloatBuffer(100);
+            var largeBuffer = imageFrame.CopyToFloatBuffer(120);
+
+            Assert.IsEmpty(normalBuffer.Where((x, i) => Math.Abs(x - largeBuffer[i]) > 1e-9));
+        }
+
+        [Test]
+        public void CopyToFloatBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
+        {
+            using var imageFrame = new ImageFrame(ImageFormat.Vec32f1, 10, 10);
+#pragma warning disable IDE0058
+            Assert.Throws<MediapipeException>(() => { imageFrame.CopyToFloatBuffer(99); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -92,7 +92,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
         }
         #endregion
 
-        #region #isDisposed
+        #region IsDisposed
         [Test]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -110,7 +110,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
         }
         #endregion
 
-        #region #SetToZero
+        #region SetToZero
         [Test]
         public void SetToZero_ShouldSetZeroToAllBytes()
         {
@@ -123,7 +123,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
         }
         #endregion
 
-        #region #SetAlignmentPaddingAreas
+        #region SetAlignmentPaddingAreas
         [Test]
         public void SetAlignmentPaddingAreas_ShouldNotThrow()
         {

--- a/Mediapipe.Net.Tests/Framework/Packet/BoolPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/BoolPacketTest.cs
@@ -1,0 +1,95 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class BoolPacketTest
+    {
+        #region Constructor
+        [Test, SignalAbort]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithNoArguments()
+        {
+            using var packet = new BoolPacket();
+#pragma warning disable IDE0058
+            Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+            Assert.Throws<MediapipeException>(() => { packet.Get(); });
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithTrue()
+        {
+            using var packet = new BoolPacket(true);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.True(packet.Get());
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithFalse()
+        {
+            using var packet = new BoolPacket(false);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.False(packet.Get());
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithValueAndTimestamp()
+        {
+            using var timestamp = new Timestamp(1);
+            using var packet = new BoolPacket(true, timestamp);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.True(packet.Get());
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var packet = new BoolPacket();
+            Assert.False(packet.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var packet = new BoolPacket();
+            packet.Dispose();
+
+            Assert.True(packet.IsDisposed);
+        }
+        #endregion
+
+        #region Consume
+        [Test]
+        public void Consume_ShouldThrowNotSupportedException()
+        {
+            using var packet = new BoolPacket();
+#pragma warning disable IDE0058
+            Assert.Throws<NotSupportedException>(() => { packet.Consume(); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region DebugTypeName
+        [Test]
+        public void DebugTypeName_ShouldReturnBool_When_ValueIsSet()
+        {
+            using var packet = new BoolPacket(true);
+            Assert.AreEqual(packet.DebugTypeName(), "bool");
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Packet/FloatArrayPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/FloatArrayPacketTest.cs
@@ -2,12 +2,12 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
+using System;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Framework;
 using Mediapipe.Net.Framework.Packet;
 using Mediapipe.Net.Framework.Port;
 using NUnit.Framework;
-using System;
 
 namespace Mediapipe.Net.Tests.Framework.Packet
 {

--- a/Mediapipe.Net.Tests/Framework/Packet/FloatArrayPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/FloatArrayPacketTest.cs
@@ -93,7 +93,11 @@ namespace Mediapipe.Net.Tests.Framework.Packet
         {
             float[] array = { 0.01f };
             using var packet = new FloatArrayPacket(array);
-            Assert.AreEqual(packet.DebugTypeName(), "float []");
+
+            Assert.AreEqual(packet.DebugTypeName(),
+                OperatingSystem.IsWindows()
+                    ? "float [0]"
+                    : "float []");
         }
         #endregion
     }

--- a/Mediapipe.Net.Tests/Framework/Packet/FloatArrayPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/FloatArrayPacketTest.cs
@@ -1,0 +1,100 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+using System;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class FloatArrayPacketTest
+    {
+        #region Constructor
+        [Test, SignalAbort]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithNoArguments()
+        {
+            using var packet = new FloatArrayPacket();
+#pragma warning disable IDE0058
+            packet.Length = 0;
+            Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+            Assert.Throws<MediapipeException>(() => { packet.Get(); });
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithEmptyArray()
+        {
+            float[] array = Array.Empty<float>();
+            using var packet = new FloatArrayPacket(array);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), array);
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithArray()
+        {
+            float[] array = { 0.01f };
+            using var packet = new FloatArrayPacket(array);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), array);
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithValueAndTimestamp()
+        {
+            float[] array = { 0.01f, 0.02f };
+            using var timestamp = new Timestamp(1);
+            using var packet = new FloatArrayPacket(array, timestamp);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), array);
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var packet = new FloatArrayPacket();
+            Assert.False(packet.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var packet = new FloatArrayPacket();
+            packet.Dispose();
+
+            Assert.True(packet.IsDisposed);
+        }
+        #endregion
+
+        #region Consume
+        [Test]
+        public void Consume_ShouldThrowNotSupportedException()
+        {
+            using var packet = new FloatArrayPacket();
+#pragma warning disable IDE0058
+            Assert.Throws<NotSupportedException>(() => { packet.Consume(); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region DebugTypeName
+        [Test]
+        public void DebugTypeName_ShouldReturnFloat_When_ValueIsSet()
+        {
+            float[] array = { 0.01f };
+            using var packet = new FloatArrayPacket(array);
+            Assert.AreEqual(packet.DebugTypeName(), "float []");
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Packet/FloatPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/FloatPacketTest.cs
@@ -2,12 +2,12 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
+using System;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Framework;
 using Mediapipe.Net.Framework.Packet;
 using Mediapipe.Net.Framework.Port;
 using NUnit.Framework;
-using System;
 
 namespace Mediapipe.Net.Tests.Framework.Packet
 {

--- a/Mediapipe.Net.Tests/Framework/Packet/FloatPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/FloatPacketTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+using System;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class FloatPacketTest
+    {
+        #region Constructor
+        [Test, SignalAbort]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithNoArguments()
+        {
+            using var packet = new FloatPacket();
+#pragma warning disable IDE0058
+            Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+            Assert.Throws<MediapipeException>(() => { packet.Get(); });
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithValue()
+        {
+            using var packet = new FloatPacket(0.01f);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), 0.01f);
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithValueAndTimestamp()
+        {
+            using var timestamp = new Timestamp(1);
+            using var packet = new FloatPacket(0.01f, timestamp);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), 0.01f);
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var packet = new FloatPacket();
+            Assert.False(packet.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var packet = new FloatPacket();
+            packet.Dispose();
+
+            Assert.True(packet.IsDisposed);
+        }
+        #endregion
+
+        #region Consume
+        [Test]
+        public void Consume_ShouldThrowNotSupportedException()
+        {
+            using var packet = new FloatPacket();
+#pragma warning disable IDE0058
+            Assert.Throws<NotSupportedException>(() => { packet.Consume(); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region DebugTypeName
+        [Test]
+        public void DebugTypeName_ShouldReturnFloat_When_ValueIsSet()
+        {
+            using var packet = new FloatPacket(0.01f);
+            Assert.AreEqual(packet.DebugTypeName(), "float");
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Packet/ImageFramePacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/ImageFramePacketTest.cs
@@ -1,0 +1,126 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Format;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class ImageFramePacketTest
+    {
+        #region Constructor
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithNoArguments()
+        {
+            using var packet = new ImageFramePacket();
+            using var statusOrImageFrame = packet.Consume();
+            Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+            Assert.AreEqual(statusOrImageFrame.Status.Code(), Status.StatusCode.Internal);
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithValue()
+        {
+            var srcImageFrame = new ImageFrame();
+
+            using var packet = new ImageFramePacket(srcImageFrame);
+            Assert.True(srcImageFrame.IsDisposed);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+
+            using var statusOrImageFrame = packet.Consume();
+            Assert.True(statusOrImageFrame.Ok());
+
+            using var imageFrame = statusOrImageFrame.Value();
+            Assert.AreEqual(imageFrame.Format(), ImageFormat.Unknown);
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithValueAndTimestamp()
+        {
+            var srcImageFrame = new ImageFrame();
+
+            using var timestamp = new Timestamp(1);
+            using var packet = new ImageFramePacket(srcImageFrame, timestamp);
+            Assert.True(srcImageFrame.IsDisposed);
+            Assert.True(packet.ValidateAsType().Ok());
+
+            using var statusOrImageFrame = packet.Consume();
+            Assert.True(statusOrImageFrame.Ok());
+
+            using var imageFrame = statusOrImageFrame.Value();
+            Assert.AreEqual(imageFrame.Format(), ImageFormat.Unknown);
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var packet = new ImageFramePacket();
+            Assert.False(packet.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var packet = new ImageFramePacket();
+            packet.Dispose();
+
+            Assert.True(packet.IsDisposed);
+        }
+        #endregion
+
+        #region Get
+        [Test, SignalAbort]
+        public void Get_ShouldThrowMediaPipeException_When_DataIsEmpty()
+        {
+            using var packet = new ImageFramePacket();
+#pragma warning disable IDE0058
+            Assert.Throws<MediapipeException>(() => { packet.Get(); });
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void Get_ShouldReturnImageFrame_When_DataIsNotEmpty()
+        {
+            using var packet = new ImageFramePacket(new ImageFrame(ImageFormat.Sbgra, 10, 10));
+            using var imageFrame = packet.Get();
+            Assert.AreEqual(imageFrame.Format(), ImageFormat.Sbgra);
+            Assert.AreEqual(imageFrame.Width(), 10);
+            Assert.AreEqual(imageFrame.Height(), 10);
+        }
+        #endregion
+
+        #region Consume
+        [Test]
+        public void Consume_ShouldReturnImageFrame()
+        {
+            using var packet = new ImageFramePacket(new ImageFrame(ImageFormat.Sbgra, 10, 10));
+            using var statusOrImageFrame = packet.Consume();
+            Assert.True(statusOrImageFrame.Ok());
+
+            using var imageFrame = statusOrImageFrame.Value();
+            Assert.AreEqual(imageFrame.Format(), ImageFormat.Sbgra);
+            Assert.AreEqual(imageFrame.Width(), 10);
+            Assert.AreEqual(imageFrame.Height(), 10);
+        }
+        #endregion
+
+        #region DebugTypeName
+        [Test]
+        public void DebugTypeName_ShouldReturnFloat_When_ValueIsSet()
+        {
+            using var packet = new ImageFramePacket(new ImageFrame());
+            Assert.AreEqual(packet.DebugTypeName(), "mediapipe::ImageFrame");
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Packet/ImageFramePacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/ImageFramePacketTest.cs
@@ -2,6 +2,7 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
+using System;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Framework;
 using Mediapipe.Net.Framework.Format;
@@ -119,7 +120,11 @@ namespace Mediapipe.Net.Tests.Framework.Packet
         public void DebugTypeName_ShouldReturnFloat_When_ValueIsSet()
         {
             using var packet = new ImageFramePacket(new ImageFrame());
-            Assert.AreEqual(packet.DebugTypeName(), "mediapipe::ImageFrame");
+
+            Assert.AreEqual(packet.DebugTypeName(),
+                OperatingSystem.IsWindows()
+                    ? "class mediapipe::ImageFrame"
+                    : "mediapipe::ImageFrame");
         }
         #endregion
     }

--- a/Mediapipe.Net.Tests/Framework/Packet/PacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/PacketTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class PacketTest
+    {
+        #region At
+        [Test]
+        public void At_ShouldReturnNewPacketWithTimestamp()
+        {
+            using var timestamp = new Timestamp(1);
+            var packet = new BoolPacket(true).At(timestamp);
+
+            // NOTE: This assert is here because `At()` returns a `Packet<T>?`.
+            // TODO: Investigate if `At()` can return a non-nullable `Packet<T>`.
+            Assert.NotNull(packet);
+            if (packet == null)
+                return;
+
+            Assert.True(packet.Get());
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+
+            using (var newTimestamp = new Timestamp(2))
+            {
+                var newPacket = packet.At(newTimestamp);
+                Assert.NotNull(newPacket);
+                if (newPacket == null)
+                    return;
+
+                Assert.IsInstanceOf<BoolPacket>(newPacket);
+                Assert.True(newPacket.Get());
+                Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+            }
+
+            Assert.True(packet.Get());
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+        #endregion
+
+        #region DebugString
+        [Test]
+        public void DebugString_ShouldReturnDebugString_When_InstantiatedWithDefaultConstructor()
+        {
+            using var packet = new BoolPacket();
+            Assert.AreEqual(packet.DebugString(), "mediapipe::Packet with timestamp: Timestamp::Unset() and no data");
+        }
+        #endregion
+
+        #region DebugTypeName
+        [Test]
+        public void DebugTypeName_ShouldReturnTypeName_When_ValueIsNotSet()
+        {
+            using var packet = new BoolPacket();
+            Assert.AreEqual(packet.DebugTypeName(), "{empty}");
+        }
+        #endregion
+
+        #region RegisteredTypeName
+        [Test]
+        public void RegisteredTypeName_ShouldReturnEmptyString()
+        {
+            using var packet = new BoolPacket();
+            Assert.AreEqual(packet.RegisteredTypeName(), "");
+        }
+        #endregion
+
+        #region ValidateAsProtoMessageLite
+        [Test]
+        public void ValidateAsProtoMessageLite_ShouldReturnInvalidArgument_When_ValueIsBool()
+        {
+            using var packet = new BoolPacket(true);
+            Assert.AreEqual(packet.ValidateAsProtoMessageLite().Code(), Status.StatusCode.InvalidArgument);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Packet/SidePacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/SidePacketTest.cs
@@ -1,0 +1,114 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework.Packet;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class SidePacketTest
+    {
+        #region Size
+        [Test]
+        public void Size_ShouldReturnZero_When_Initialized()
+        {
+            using var sidePacket = new SidePacket();
+            Assert.AreEqual(sidePacket.Size, 0);
+        }
+
+        [Test]
+        public void Size_ShouldReturnSize_When_AfterPacketsAreEmplaced()
+        {
+            using var sidePacket = new SidePacket();
+            var flagPacket = new BoolPacket(true);
+            var valuePacket = new FloatPacket(1.0f);
+            sidePacket.Emplace("flag", flagPacket);
+            sidePacket.Emplace("value", valuePacket);
+
+            Assert.AreEqual(sidePacket.Size, 2);
+            Assert.True(flagPacket.IsDisposed);
+            Assert.True(valuePacket.IsDisposed);
+        }
+        #endregion
+
+        #region Emplace
+        [Test]
+        public void Emplace_ShouldInsertAndDisposePacket()
+        {
+            using var sidePacket = new SidePacket();
+            Assert.AreEqual(sidePacket.Size, 0);
+            Assert.IsNull(sidePacket.At<FloatPacket>("value"));
+
+            var flagPacket = new FloatPacket(1.0f);
+            sidePacket.Emplace("value", flagPacket);
+
+            Assert.AreEqual(sidePacket.Size, 1);
+            Assert.AreEqual(sidePacket.At<FloatPacket>("value")?.Get(), 1.0f);
+            Assert.True(flagPacket.IsDisposed);
+        }
+
+        [Test]
+        public void Emplace_ShouldIgnoreValue_When_KeyExists()
+        {
+            using (var sidePacket = new SidePacket())
+            {
+                var oldValuePacket = new FloatPacket(1.0f);
+                sidePacket.Emplace("value", oldValuePacket);
+                Assert.AreEqual(sidePacket.At<FloatPacket>("value")?.Get(), 1.0f);
+
+                var newValuePacket = new FloatPacket(2.0f);
+                sidePacket.Emplace("value", newValuePacket);
+                Assert.AreEqual(sidePacket.At<FloatPacket>("value")?.Get(), 1.0f);
+            }
+        }
+        #endregion
+
+        #region Erase
+        [Test]
+        public void Erase_ShouldDoNothing_When_KeyDoesNotExist()
+        {
+            using var sidePacket = new SidePacket();
+            var count = sidePacket.Erase("value");
+
+            Assert.AreEqual(sidePacket.Size, 0);
+            Assert.AreEqual(count, 0);
+        }
+
+        [Test]
+        public void Erase_ShouldEraseKey_When_KeyExists()
+        {
+            using var sidePacket = new SidePacket();
+            sidePacket.Emplace("value", new BoolPacket(true));
+            Assert.AreEqual(sidePacket.Size, 1);
+
+            var count = sidePacket.Erase("value");
+            Assert.AreEqual(sidePacket.Size, 0);
+            Assert.AreEqual(count, 1);
+        }
+        #endregion
+
+        #region Clear
+        [Test]
+        public void Clear_ShouldDoNothing_When_SizeIsZero()
+        {
+            using var sidePacket = new SidePacket();
+            sidePacket.Clear();
+
+            Assert.AreEqual(sidePacket.Size, 0);
+        }
+
+        [Test]
+        public void Clear_ShouldClearAllKeys_When_SizeIsNotZero()
+        {
+            using var sidePacket = new SidePacket();
+            sidePacket.Emplace("flag", new BoolPacket(true));
+            sidePacket.Emplace("value", new FloatPacket(1.0f));
+            Assert.AreEqual(sidePacket.Size, 2);
+
+            sidePacket.Clear();
+            Assert.AreEqual(sidePacket.Size, 0);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Packet/StringPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/StringPacketTest.cs
@@ -2,13 +2,13 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
+using System;
+using System.Text.RegularExpressions;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Framework;
 using Mediapipe.Net.Framework.Packet;
 using Mediapipe.Net.Framework.Port;
 using NUnit.Framework;
-using System;
-using System.Text.RegularExpressions;
 
 namespace Mediapipe.Net.Tests.Framework.Packet
 {

--- a/Mediapipe.Net.Tests/Framework/Packet/StringPacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/StringPacketTest.cs
@@ -1,0 +1,122 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+using System;
+using System.Text.RegularExpressions;
+
+namespace Mediapipe.Net.Tests.Framework.Packet
+{
+    public class StringPacketTest
+    {
+        #region Constructor
+        [Test, SignalAbort]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithNoArguments()
+        {
+            using var packet = new StringPacket();
+#pragma warning disable IDE0058
+            Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+            Assert.Throws<MediapipeException>(() => { packet.Get(); });
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithString()
+        {
+            using var packet = new StringPacket("test");
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), "test");
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithByteArray()
+        {
+            var bytes = new byte[] { (byte)'t', (byte)'e', (byte)'s', (byte)'t' };
+            using var packet = new StringPacket(bytes);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), "test");
+            Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithStringAndTimestamp()
+        {
+            using var timestamp = new Timestamp(1);
+            using var packet = new StringPacket("test", timestamp);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), "test");
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+
+        [Test]
+        public void Ctor_ShouldInstantiatePacket_When_CalledWithByteArrayAndTimestamp()
+        {
+            var bytes = new byte[] { (byte)'t', (byte)'e', (byte)'s', (byte)'t' };
+            using var timestamp = new Timestamp(1);
+            using var packet = new StringPacket(bytes, timestamp);
+            Assert.True(packet.ValidateAsType().Ok());
+            Assert.AreEqual(packet.Get(), "test");
+            Assert.AreEqual(packet.Timestamp(), timestamp);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var packet = new StringPacket();
+            Assert.False(packet.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var packet = new StringPacket();
+            packet.Dispose();
+
+            Assert.True(packet.IsDisposed);
+        }
+        #endregion
+
+        #region GetByteArray
+        [Test]
+        public void GetByteArray_ShouldReturnByteArray()
+        {
+            var bytes = new byte[] { (byte)'a', (byte)'b', 0, (byte)'c' };
+            using var packet = new StringPacket(bytes);
+            Assert.AreEqual(packet.GetByteArray(), bytes);
+            Assert.AreEqual(packet.Get(), "ab");
+        }
+        #endregion
+
+        #region Consume
+        [Test]
+        public void Consume_ShouldThrowNotSupportedException()
+        {
+            using var packet = new StringPacket();
+#pragma warning disable IDE0058
+            Assert.Throws<NotSupportedException>(() => { packet.Consume(); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region DebugTypeName
+        [Test]
+        public void DebugTypeName_ShouldReturnString_When_ValueIsSet()
+        {
+            using var packet = new StringPacket("test");
+
+            var regex = new Regex("string");
+            Assert.True(regex.IsMatch(packet.DebugTypeName() ?? ""));
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Port/StatusOrGpuResourcesTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusOrGpuResourcesTest.cs
@@ -1,0 +1,53 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Gpu;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Port
+{
+    public class StatusOrGpuResourcesTest
+    {
+        #region #status
+        [Test, GpuOnly]
+        public void Status_ShouldReturnOk_When_StatusIsOk()
+        {
+            using var statusOrGpuResources = GpuResources.Create();
+            Assert.AreEqual(statusOrGpuResources.Status.Code(), Status.StatusCode.Ok);
+        }
+        #endregion
+
+        #region #isDisposed
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var statusOrGpuResources = GpuResources.Create();
+            Assert.False(statusOrGpuResources.IsDisposed);
+        }
+
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var statusOrGpuResources = GpuResources.Create();
+            statusOrGpuResources.Dispose();
+
+            Assert.True(statusOrGpuResources.IsDisposed);
+        }
+        #endregion
+
+        #region #Value
+        [Test, GpuOnly]
+        public void Value_ShouldReturnGpuResources_When_StatusIsOk()
+        {
+            using var statusOrGpuResources = GpuResources.Create();
+            Assert.True(statusOrGpuResources.Ok());
+
+            using var gpuResources = statusOrGpuResources.Value();
+            Assert.IsInstanceOf<GpuResources>(gpuResources);
+            Assert.True(statusOrGpuResources.IsDisposed);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Port/StatusOrGpuResourcesTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusOrGpuResourcesTest.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
 {
     public class StatusOrGpuResourcesTest
     {
-        #region #status
+        #region Status
         [Test, GpuOnly]
         public void Status_ShouldReturnOk_When_StatusIsOk()
         {
@@ -19,7 +19,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #isDisposed
+        #region IsDisposed
         [Test, GpuOnly]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -37,7 +37,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #Value
+        #region Value
         [Test, GpuOnly]
         public void Value_ShouldReturnGpuResources_When_StatusIsOk()
         {

--- a/Mediapipe.Net.Tests/Framework/Port/StatusOrImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusOrImageFrameTest.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
 {
     public class StatusOrImageFrameTest
     {
-        #region #status
+        #region Status
         [Test]
         public void Status_ShouldReturnOk_When_StatusIsOk()
         {
@@ -22,7 +22,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #isDisposed
+        #region IsDisposed
         [Test]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -40,7 +40,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #Value
+        #region Value
         [Test]
         public void Value_ShouldReturnImageFrame_When_StatusIsOk()
         {

--- a/Mediapipe.Net.Tests/Framework/Port/StatusOrImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusOrImageFrameTest.cs
@@ -1,0 +1,65 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework;
+using Mediapipe.Net.Framework.Format;
+using Mediapipe.Net.Framework.Packet;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Port
+{
+    public class StatusOrImageFrameTest
+    {
+        #region #status
+        [Test]
+        public void Status_ShouldReturnOk_When_StatusIsOk()
+        {
+            using var statusOrImageFrame = initializeSubject();
+            Assert.True(statusOrImageFrame.Ok());
+            Assert.AreEqual(statusOrImageFrame.Status.Code(), Status.StatusCode.Ok);
+        }
+        #endregion
+
+        #region #isDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var statusOrImageFrame = initializeSubject();
+            Assert.False(statusOrImageFrame.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var statusOrImageFrame = initializeSubject();
+            statusOrImageFrame.Dispose();
+
+            Assert.True(statusOrImageFrame.IsDisposed);
+        }
+        #endregion
+
+        #region #Value
+        [Test]
+        public void Value_ShouldReturnImageFrame_When_StatusIsOk()
+        {
+            using var statusOrImageFrame = initializeSubject();
+            Assert.True(statusOrImageFrame.Ok());
+
+            using var imageFrame = statusOrImageFrame.Value();
+            Assert.AreEqual(imageFrame.Width(), 10);
+            Assert.AreEqual(imageFrame.Height(), 10);
+            Assert.True(statusOrImageFrame.IsDisposed);
+        }
+        #endregion
+
+        private StatusOrImageFrame initializeSubject()
+        {
+            var imageFrame = new ImageFrame(ImageFormat.Sbgra, 10, 10);
+            var packet = new ImageFramePacket(imageFrame, new Timestamp(1));
+
+            return (StatusOrImageFrame)packet.Consume();
+        }
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Port/StatusTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusTest.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Core;
+using Mediapipe.Net.Framework.Port;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework.Port
+{
+    public class StatusTest
+    {
+        #region #Code
+        [Test]
+        public void Code_ShouldReturnStatusCode_When_StatusIsOk()
+        {
+            using var status = Status.Ok();
+            Assert.AreEqual(status.Code(), Status.StatusCode.Ok);
+        }
+
+        [Test]
+        public void Code_ShouldReturnStatusCode_When_StatusIsFailedPrecondition()
+        {
+            using var status = Status.FailedPrecondition();
+            Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
+        }
+        #endregion
+
+        #region #IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var status = Status.Ok();
+            Assert.False(status.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var status = Status.Ok();
+            status.Dispose();
+
+            Assert.True(status.IsDisposed);
+        }
+        #endregion
+
+        #region #RawCode
+        [Test]
+        public void RawCode_ShouldReturnRawCode_When_StatusIsOk()
+        {
+            using var status = Status.Ok();
+            Assert.AreEqual(status.RawCode(), 0);
+        }
+
+        [Test]
+        public void RawCode_ShouldReturnRawCode_When_StatusIsFailedPrecondition()
+        {
+            using var status = Status.FailedPrecondition();
+            Assert.AreEqual(status.RawCode(), 9);
+        }
+        #endregion
+
+        #region #Ok
+        [Test]
+        public void Ok_ShouldReturnTrue_When_StatusIsOk()
+        {
+            using var status = Status.Ok();
+            Assert.True(status.Ok());
+        }
+
+        [Test]
+        public void Ok_ShouldReturnFalse_When_StatusIsFailedPrecondition()
+        {
+            using var status = Status.FailedPrecondition();
+            Assert.False(status.Ok());
+        }
+        #endregion
+
+        #region #AssertOk
+        [Test]
+        public void AssertOk_ShouldNotThrow_When_StatusIsOk()
+        {
+            using var status = Status.Ok();
+            Assert.DoesNotThrow(() => { status.AssertOk(); });
+        }
+
+        [Test]
+        public void AssertOk_ShouldThrow_When_StatusIsNotOk()
+        {
+            using var status = Status.FailedPrecondition();
+#pragma warning disable IDE0058
+            Assert.Throws<MediapipeException>(() => { status.AssertOk(); });
+
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region #ToString
+        [Test]
+        public void ToString_ShouldReturnMessage_When_StatusIsOk()
+        {
+            using var status = Status.Ok();
+            Assert.AreEqual(status.ToString(), "OK");
+        }
+
+        [Test]
+        public void ToString_ShouldReturnMessage_When_StatusIsFailedPrecondition()
+        {
+            var message = "Some error";
+            using var status = Status.FailedPrecondition(message);
+            Assert.AreEqual(status.ToString(), $"FAILED_PRECONDITION: {message}");
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Port/StatusTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) homuler and Vignette
+// Copyright (c) homuler and Vignette
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 

--- a/Mediapipe.Net.Tests/Framework/Port/StatusTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Port/StatusTest.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
 {
     public class StatusTest
     {
-        #region #Code
+        #region Code
         [Test]
         public void Code_ShouldReturnStatusCode_When_StatusIsOk()
         {
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #IsDisposed
+        #region IsDisposed
         [Test]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -44,7 +44,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #RawCode
+        #region RawCode
         [Test]
         public void RawCode_ShouldReturnRawCode_When_StatusIsOk()
         {
@@ -60,7 +60,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #Ok
+        #region Ok
         [Test]
         public void Ok_ShouldReturnTrue_When_StatusIsOk()
         {
@@ -76,7 +76,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #AssertOk
+        #region AssertOk
         [Test]
         public void AssertOk_ShouldNotThrow_When_StatusIsOk()
         {
@@ -95,7 +95,7 @@ namespace Mediapipe.Net.Tests.Framework.Port
         }
         #endregion
 
-        #region #ToString
+        #region ToString
         [Test]
         public void ToString_ShouldReturnMessage_When_StatusIsOk()
         {

--- a/Mediapipe.Net.Tests/Framework/TimestampTest.cs
+++ b/Mediapipe.Net.Tests/Framework/TimestampTest.cs
@@ -9,7 +9,7 @@ namespace Mediapipe.Net.Tests.Framework
 {
     public class TimestampTest
     {
-        #region #IsDisposed
+        #region IsDisposed
         [Test]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -27,7 +27,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #Value
+        #region Value
         [Test]
         public void Value_ShouldReturnValue()
         {
@@ -36,7 +36,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #Seconds
+        #region Seconds
         [Test]
         public void Seconds_ShouldReturnValueInSeconds()
         {
@@ -45,7 +45,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #Microseconds
+        #region Microseconds
         [Test]
         public void Microseconds_ShouldReturnValueInMicroseconds()
         {
@@ -54,7 +54,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #IsSpecialValue
+        #region IsSpecialValue
         [Test]
         public void IsSpecialValue_ShouldReturnFalse_When_ValueIsInRange()
         {
@@ -77,7 +77,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #IsRangeValue
+        #region IsRangeValue
         [Test]
         public void IsRangeValue_ShouldReturnTrue_When_ValueIsInRange()
         {
@@ -114,7 +114,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #IsAllowedInStream
+        #region IsAllowedInStream
         [Test]
         public void IsAllowedInStream_ShouldReturnTrue_When_ValueIsInRange()
         {
@@ -137,7 +137,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #DebugString
+        #region DebugString
         [Test]
         public void DebugString_ShouldReturnDebugString()
         {
@@ -153,7 +153,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #NextAllowedInStream
+        #region NextAllowedInStream
         [Test]
         public void NextAllowedInStream_ShouldReturnNextTimestamp_When_ValueIsInRange()
         {
@@ -171,7 +171,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #PreviousAllowedInStream
+        #region PreviousAllowedInStream
         [Test]
         public void PreviousAllowedInStream_ShouldReturnPreviousTimestamp_When_ValueIsInRange()
         {
@@ -189,7 +189,7 @@ namespace Mediapipe.Net.Tests.Framework
         }
         #endregion
 
-        #region #FromSeconds
+        #region FromSeconds
         [Test]
         public void FromSeconds_ShouldReturnTimestamp()
         {

--- a/Mediapipe.Net.Tests/Framework/TimestampTest.cs
+++ b/Mediapipe.Net.Tests/Framework/TimestampTest.cs
@@ -1,0 +1,201 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Framework
+{
+    public class TimestampTest
+    {
+        #region #IsDisposed
+        [Test]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var timestamp = new Timestamp(1);
+            Assert.False(timestamp.IsDisposed);
+        }
+
+        [Test]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var timestamp = new Timestamp(1);
+            timestamp.Dispose();
+
+            Assert.True(timestamp.IsDisposed);
+        }
+        #endregion
+
+        #region #Value
+        [Test]
+        public void Value_ShouldReturnValue()
+        {
+            using var timestamp = new Timestamp(10);
+            Assert.AreEqual(timestamp.Value(), 10);
+        }
+        #endregion
+
+        #region #Seconds
+        [Test]
+        public void Seconds_ShouldReturnValueInSeconds()
+        {
+            using var timestamp = new Timestamp(1_000_000);
+            Assert.AreEqual(timestamp.Seconds(), 1d, 1e-9);
+        }
+        #endregion
+
+        #region #Microseconds
+        [Test]
+        public void Microseconds_ShouldReturnValueInMicroseconds()
+        {
+            using var timestamp = new Timestamp(1_000_000);
+            Assert.AreEqual(timestamp.Microseconds(), 1_000_000);
+        }
+        #endregion
+
+        #region #IsSpecialValue
+        [Test]
+        public void IsSpecialValue_ShouldReturnFalse_When_ValueIsInRange()
+        {
+            using var timestamp = new Timestamp(1);
+            Assert.False(timestamp.IsSpecialValue());
+        }
+
+        [Test]
+        public void IsSpecialValue_ShouldReturnTrue_When_TimestampIsUnset()
+        {
+            using var timestamp = Timestamp.Unset();
+            Assert.True(timestamp.IsSpecialValue());
+        }
+
+        [Test]
+        public void IsSpecialValue_ShouldReturnTrue_When_TimestampIsUnstarted()
+        {
+            using var timestamp = Timestamp.Unstarted();
+            Assert.True(timestamp.IsSpecialValue());
+        }
+        #endregion
+
+        #region #IsRangeValue
+        [Test]
+        public void IsRangeValue_ShouldReturnTrue_When_ValueIsInRange()
+        {
+            using var timestamp = new Timestamp(1);
+            Assert.True(timestamp.IsRangeValue());
+        }
+
+        [Test]
+        public void IsRangeValue_ShouldReturnFalse_When_TimestampIsPreStream()
+        {
+            using var timestamp = Timestamp.PreStream();
+            Assert.False(timestamp.IsRangeValue());
+        }
+
+        [Test]
+        public void IsRangeValue_ShouldReturnFalse_When_TimestampIsPostStream()
+        {
+            using var timestamp = Timestamp.PostStream();
+            Assert.False(timestamp.IsRangeValue());
+        }
+
+        [Test]
+        public void IsRangeValue_ShouldReturnTrue_When_TimestampIsMin()
+        {
+            using var timestamp = Timestamp.Min();
+            Assert.True(timestamp.IsRangeValue());
+        }
+
+        [Test]
+        public void IsRangeValue_ShouldReturnTrue_When_TimestampIsMax()
+        {
+            using var timestamp = Timestamp.Max();
+            Assert.True(timestamp.IsRangeValue());
+        }
+        #endregion
+
+        #region #IsAllowedInStream
+        [Test]
+        public void IsAllowedInStream_ShouldReturnTrue_When_ValueIsInRange()
+        {
+            using var timestamp = new Timestamp(1);
+            Assert.True(timestamp.IsAllowedInStream());
+        }
+
+        [Test]
+        public void IsAllowedInStream_ShouldReturnFalse_When_TimestampIsOneOverPostStream()
+        {
+            using var timestamp = Timestamp.OneOverPostStream();
+            Assert.False(timestamp.IsAllowedInStream());
+        }
+
+        [Test]
+        public void IsAllowedInStream_ShouldReturnFalse_When_TimestampIsDone()
+        {
+            using var timestamp = Timestamp.Done();
+            Assert.False(timestamp.IsAllowedInStream());
+        }
+        #endregion
+
+        #region #DebugString
+        [Test]
+        public void DebugString_ShouldReturnDebugString()
+        {
+            using var timestamp = new Timestamp(1);
+            Assert.AreEqual(timestamp.DebugString(), "1");
+        }
+
+        [Test]
+        public void DebugString_ShouldReturnDebugString_When_TimestampIsUnset()
+        {
+            using var timestamp = Timestamp.Unset();
+            Assert.AreEqual(timestamp.DebugString(), "Timestamp::Unset()");
+        }
+        #endregion
+
+        #region #NextAllowedInStream
+        [Test]
+        public void NextAllowedInStream_ShouldReturnNextTimestamp_When_ValueIsInRange()
+        {
+            using var timestamp = new Timestamp(1);
+            using var nextTimestamp = timestamp.NextAllowedInStream();
+            Assert.AreEqual(nextTimestamp.Microseconds(), 2);
+        }
+
+        [Test]
+        public void NextAllowedInStream_ShouldReturnOneOverPostStream_When_TimestampIsPostStream()
+        {
+            using var timestamp = Timestamp.PostStream();
+            using var nextTimestamp = timestamp.NextAllowedInStream();
+            Assert.AreEqual(nextTimestamp, Timestamp.OneOverPostStream());
+        }
+        #endregion
+
+        #region #PreviousAllowedInStream
+        [Test]
+        public void PreviousAllowedInStream_ShouldReturnPreviousTimestamp_When_ValueIsInRange()
+        {
+            using var timestamp = new Timestamp(1);
+            using var nextTimestamp = timestamp.PreviousAllowedInStream();
+            Assert.AreEqual(nextTimestamp.Microseconds(), 0);
+        }
+
+        [Test]
+        public void PreviousAllowedInStream_ShouldReturnUnstarted_When_TimestampIsPreStream()
+        {
+            using var timestamp = Timestamp.PreStream();
+            using var nextTimestamp = timestamp.PreviousAllowedInStream();
+            Assert.AreEqual(nextTimestamp, Timestamp.Unstarted());
+        }
+        #endregion
+
+        #region #FromSeconds
+        [Test]
+        public void FromSeconds_ShouldReturnTimestamp()
+        {
+            using var timestamp = Timestamp.FromSeconds(1d);
+            Assert.AreEqual(timestamp.Microseconds(), 1_000_000);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Tool/NameUtilTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Tool/NameUtilTest.cs
@@ -1,0 +1,156 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Protobuf;
+using NUnit.Framework;
+using static Mediapipe.Net.Framework.Tool.Tool;
+
+namespace Mediapipe.Net.Tests.Framework.Tool
+{
+    public class NameUtilTest
+    {
+        [TestCase("{}", "base", "base")]
+        [TestCase(@"{""node"":[{""name"":""a""}]}", "base", "base")]
+        [TestCase(@"{""node"":[{},{}]}", "", "")]
+        [TestCase(@"{""node"":[{""name"":""base""},{""name"":""base_02""}]}", "base", "base_03")]
+        public void GetUnusedNodeName_ShouldReturnUniqueName(string configJson, string nameBase, string uniqueName)
+        {
+            var config = CalculatorGraphConfig.Parser.ParseJson(configJson);
+            Assert.AreEqual(GetUnusedNodeName(config, nameBase), uniqueName);
+        }
+
+        [TestCase("{}", "base", "base")]
+        [TestCase(@"{""node"":[{""input_side_packet"":[""a""]}]}", "base", "base")]
+        [TestCase(@"{""node"":[{},{""input_side_packet"":[]}]}", "", "")]
+        [TestCase(@"{""node"":[{""input_side_packet"":[""base""]},{""input_side_packet"":[""TAG:base_02""]}]}", "base", "base_03")]
+        public void GetUnusedSidePacketName_ShouldReturnUniqueName(string configJson, string nameBase, string uniqueName)
+        {
+            var config = CalculatorGraphConfig.Parser.ParseJson(configJson);
+            Assert.AreEqual(GetUnusedSidePacketName(config, nameBase), uniqueName);
+        }
+
+        [TestCase(@"{""node"":[{""name"":""x""}]}", 0, "x")]
+        [TestCase(@"{""node"":[{""name"":""x""},{""name"":""x""},{""name"":""y""},{""name"":""x""}]}", 0, "x_1")]
+        [TestCase(@"{""node"":[{""name"":""x""},{""name"":""x""},{""name"":""y""},{""name"":""x""}]}", 1, "x_2")]
+        [TestCase(@"{""node"":[{""name"":""x""},{""name"":""x""},{""name"":""y""},{""name"":""x""}]}", 2, "y")]
+        [TestCase(@"{""node"":[{""name"":""x""},{""name"":""x""},{""name"":""y""},{""name"":""x""}]}", 3, "x_3")]
+        [TestCase(@"{""node"":[{""calculator"":""x""},{""name"":""x""}]}", 0, "x_1")]
+        [TestCase(@"{""node"":[{""calculator"":""x""},{""name"":""x""}]}", 1, "x_2")]
+        [TestCase(@"{""node"":[{""name"":""x""},{""calculator"":""x""}]}", 0, "x_1")]
+        [TestCase(@"{""node"":[{""name"":""x""},{""calculator"":""x""}]}", 1, "x_2")]
+        public void CanonicalNodeName_ShouldReturnCanonicalNodeName_When_NodeIdIsValid(string configJson, int nodeId, string name)
+        {
+            var config = CalculatorGraphConfig.Parser.ParseJson(configJson);
+            Assert.AreEqual(CanonicalNodeName(config, nodeId), name);
+        }
+
+        [Test]
+        public void CanonicalNodeName_ShouldThrow_When_NodeIdIsNegative()
+        {
+            var config = CalculatorGraphConfig.Parser.ParseJson(@"{""node"":[{""name"":""name""}]}");
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentOutOfRangeException>(() => { CanonicalNodeName(config, -1); });
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void CanonicalNodeName_ShouldThrow_When_NodeIdIsInvalid()
+        {
+            var config = CalculatorGraphConfig.Parser.ParseJson(@"{""node"":[{""name"":""name""}]}");
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentOutOfRangeException>(() => { CanonicalNodeName(config, 1); });
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void CanonicalNodeName_ShouldThrow_When_NodeIsEmpty()
+        {
+            var config = CalculatorGraphConfig.Parser.ParseJson("{}");
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentOutOfRangeException>(() => { CanonicalNodeName(config, 0); });
+#pragma warning restore IDE0058
+        }
+
+        [TestCase("stream", "stream")]
+        [TestCase("TAG:x", "x")]
+        [TestCase("TAG:1:x", "x")]
+        public void ParseNameFromStream_ShouldReturnName_When_InputIsValid(string stream, string name)
+        {
+            Assert.AreEqual(ParseNameFromStream(stream), name);
+        }
+
+        [TestCase(":stream")]
+        [TestCase("TAG::stream")]
+        [TestCase("TAG:1:")]
+        public void ParseNameFromStream_ShouldThrow_When_InputIsInvalid(string stream)
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ParseNameFromStream(stream); });
+#pragma warning restore IDE0058
+        }
+
+        [TestCase("", "", 0)]
+        [TestCase("TAG", "TAG", 0)]
+        [TestCase(":1", "", 1)]
+        [TestCase("TAG:1", "TAG", 1)]
+        public void ParseTagIndex_ShouldReturnTagIndexPair_When_InputIsValid(string tagIndex, string tag, int index)
+        {
+            var output = ParseTagIndex(tagIndex);
+
+            Assert.AreEqual(output.Item1, tag);
+            Assert.AreEqual(output.Item2, index);
+        }
+
+        [TestCase("tag")]
+        [TestCase(":")]
+        [TestCase("TAG:")]
+        [TestCase("1")]
+        public void ParseTagIndex_ShouldThrow_When_InputIsInvalid(string tagIndex)
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ParseTagIndex(tagIndex); });
+#pragma warning restore IDE0058
+        }
+
+        [TestCase("stream", "", -1)]
+        [TestCase("TAG:x", "TAG", 0)]
+        [TestCase("TAG:1:x", "TAG", 1)]
+        public void ParseTagIndexFromStream_ShouldReturnTagIndexPair_When_InputIsValid(string stream, string tag, int index)
+        {
+            var output = ParseTagIndexFromStream(stream);
+
+            Assert.AreEqual(output.Item1, tag);
+            Assert.AreEqual(output.Item2, index);
+        }
+
+        [TestCase(":stream")]
+        [TestCase("TAG::stream")]
+        [TestCase("TAG:1:")]
+        public void ParseTagIndexFromStream_ShouldThrow_When_InputIsInvalid(string stream)
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ParseTagIndexFromStream(stream); });
+#pragma warning restore IDE0058
+        }
+
+        [TestCase("", -1, "")]
+        [TestCase("", 1, "")]
+        [TestCase("TAG", -1, "TAG")]
+        [TestCase("TAG", 1, "TAG:1")]
+        public void CatTag_ShouldReturnTag(string tag, int index, string output)
+        {
+            Assert.AreEqual(CatTag(tag, index), output);
+        }
+
+        [TestCase("", -1, "x", "x")]
+        [TestCase("", 1, "x", "x")]
+        [TestCase("TAG", -1, "x", "TAG:x")]
+        [TestCase("TAG", 1, "x", "TAG:1:x")]
+        public void CatStream_ShouldReturnStream(string tag, int index, string name, string output)
+        {
+            Assert.AreEqual(CatStream((tag, index), name), output);
+        }
+    }
+}

--- a/Mediapipe.Net.Tests/Framework/Tool/ValidateNameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Tool/ValidateNameTest.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Tests.Framework.Tool
 {
     public class ValidateNameTest
     {
-        #region .ValidateName
+        #region ValidateName
         [TestCase("humphrey")]
         [TestCase("humphrey_bogart")]
         [TestCase("humphrey_bogart_1899")]
@@ -48,7 +48,7 @@ namespace Mediapipe.Net.Tests.Framework.Tool
         }
         #endregion
 
-        #region .ValidateNumber
+        #region ValidateNumber
         [TestCase("0")]
         [TestCase("10")]
         [TestCase("1234567890")]
@@ -67,7 +67,7 @@ namespace Mediapipe.Net.Tests.Framework.Tool
         }
         #endregion
 
-        #region .ValidateTag
+        #region ValidateTag
         [TestCase("MALE")]
         [TestCase("MALE_ACTOR")]
         [TestCase("ACTOR_1899")]
@@ -102,7 +102,7 @@ namespace Mediapipe.Net.Tests.Framework.Tool
         }
         #endregion
 
-        #region .ParseTagAndName
+        #region ParseTagAndName
         [TestCase("MALE:humphrey", "MALE", "humphrey")]
         [TestCase("ACTOR:humphrey_bogart", "ACTOR", "humphrey_bogart")]
         [TestCase("ACTOR_1899:humphrey_1899", "ACTOR_1899", "humphrey_1899")]
@@ -143,7 +143,7 @@ namespace Mediapipe.Net.Tests.Framework.Tool
         }
         #endregion
 
-        #region .ParseTagIndexName
+        #region ParseTagIndexName
         [TestCase("MALE:humphrey", "MALE", 0, "humphrey")]
         [TestCase("ACTOR:humphrey_bogart", "ACTOR", 0, "humphrey_bogart")]
         [TestCase("ACTOR_1899:humphrey_1899", "ACTOR_1899", 0, "humphrey_1899")]
@@ -222,7 +222,7 @@ namespace Mediapipe.Net.Tests.Framework.Tool
         }
         #endregion
 
-        #region .ParseTagIndex
+        #region ParseTagIndex
         [TestCase("", "", 0)]
         [TestCase("VIDEO:0", "VIDEO", 0)]
         [TestCase("VIDEO:1", "VIDEO", 1)]

--- a/Mediapipe.Net.Tests/Framework/Tool/ValidateNameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Tool/ValidateNameTest.cs
@@ -1,0 +1,289 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using NUnit.Framework;
+using static Mediapipe.Net.Framework.Tool.Tool;
+
+namespace Mediapipe.Net.Tests.Framework.Tool
+{
+    public class ValidateNameTest
+    {
+        #region .ValidateName
+        [TestCase("humphrey")]
+        [TestCase("humphrey_bogart")]
+        [TestCase("humphrey_bogart_1899")]
+        [TestCase("aa")]
+        [TestCase("b1")]
+        [TestCase("_1")]
+        public void ValidateName_ShouldNotThrow_WhenNameIsValid(string name)
+        {
+            Assert.DoesNotThrow(() => { ValidateName(name); });
+        }
+
+        [TestCase("")]
+        [TestCase("humphrey bogart")]
+        [TestCase("humphreyBogart")]
+        [TestCase("humphrey-bogart")]
+        [TestCase("humphrey/bogart")]
+        [TestCase("humphrey.bogart")]
+        [TestCase("humphrey:bogart")]
+        [TestCase("1ST")]
+        [TestCase("7_ELEVEN")]
+        [TestCase("401K")]
+        [TestCase("0")]
+        [TestCase("1")]
+        [TestCase("11")]
+        [TestCase("92091")]
+        [TestCase("1st")]
+        [TestCase("7_eleven")]
+        [TestCase("401k")]
+        [TestCase("\0contains_escapes\t")]
+        public void ValidateName_ShouldThrow_WhenNameIsInvalid(string name)
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ValidateName(name); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region .ValidateNumber
+        [TestCase("0")]
+        [TestCase("10")]
+        [TestCase("1234567890")]
+        public void ValidateNumber_ShouldNotThrow_WhenNumberIsValid(string number)
+        {
+            Assert.DoesNotThrow(() => { ValidateNumber(number); });
+        }
+
+        [TestCase("01")]
+        [TestCase("1a")]
+        public void ValidateNumber_ShouldThrow_WhenNumberIsInvalid(string number)
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ValidateNumber(number); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region .ValidateTag
+        [TestCase("MALE")]
+        [TestCase("MALE_ACTOR")]
+        [TestCase("ACTOR_1899")]
+        [TestCase("AA")]
+        [TestCase("B1")]
+        [TestCase("_1")]
+        public void ValidateTag_ShouldNotThrow_WhenTagIsValid(string tag)
+        {
+            Assert.DoesNotThrow(() => { ValidateTag(tag); });
+        }
+
+        [TestCase("")]
+        [TestCase("MALE ACTOR")]
+        [TestCase("MALEaCTOR")]
+        [TestCase("MALE-ACTOR")]
+        [TestCase("MALE/ACTOR")]
+        [TestCase("MALE.ACTOR")]
+        [TestCase("MALE:ACTOR")]
+        [TestCase("0")]
+        [TestCase("1")]
+        [TestCase("11")]
+        [TestCase("92091")]
+        [TestCase("1ST")]
+        [TestCase("7_ELEVEN")]
+        [TestCase("401K")]
+        [TestCase("\0CONTAINS_ESCAPES\t")]
+        public void ValidateTag_ShouldThrow_WhenTagIsInvalid(string tag)
+        {
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ValidateTag(tag); });
+#pragma warning restore IDE0058
+        }
+        #endregion
+
+        #region .ParseTagAndName
+        [TestCase("MALE:humphrey", "MALE", "humphrey")]
+        [TestCase("ACTOR:humphrey_bogart", "ACTOR", "humphrey_bogart")]
+        [TestCase("ACTOR_1899:humphrey_1899", "ACTOR_1899", "humphrey_1899")]
+        [TestCase("humphrey_bogart", "", "humphrey_bogart")]
+        [TestCase("ACTOR:humphrey", "ACTOR", "humphrey")]
+        public void ParseTagAndName_ShouldParseInput_When_InputIsValid(string input, string expectedTag, string expectedName)
+        {
+            ParseTagAndName(input, out var tag, out var name);
+
+            Assert.AreEqual(tag, expectedTag);
+            Assert.AreEqual(name, expectedName);
+        }
+
+        [TestCase(":humphrey")]
+        [TestCase("humphrey bogart")]
+        [TestCase("actor:humphrey")]
+        [TestCase("actor:humphrey")]
+        [TestCase("ACTOR:HUMPHREY")]
+        public void ParseTagAndName_ShouldThrow_When_InputIsInvalid(string input)
+        {
+            var tag = "UNTOUCHED";
+            var name = "untouched";
+
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ParseTagAndName(input, out tag, out name); });
+            Assert.AreEqual(tag, "UNTOUCHED");
+            Assert.AreEqual(name, "untouched");
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void ParseTagAndName_ShouldThrow_When_InputIncludesBadCharacters(
+          [Values(' ', '-', '/', '.', ':')] char ch,
+          [Values("MALE$0ACTOR:humphrey", "ACTOR:humphrey$0:bogart")] string str
+        )
+        {
+            ParseTagAndName_ShouldThrow_When_InputIsInvalid(str.Replace("$0", $"{ch}"));
+        }
+        #endregion
+
+        #region .ParseTagIndexName
+        [TestCase("MALE:humphrey", "MALE", 0, "humphrey")]
+        [TestCase("ACTOR:humphrey_bogart", "ACTOR", 0, "humphrey_bogart")]
+        [TestCase("ACTOR_1899:humphrey_1899", "ACTOR_1899", 0, "humphrey_1899")]
+        [TestCase("humphrey_bogart", "", -1, "humphrey_bogart")]
+        [TestCase("ACTRESS:3:mieko_harada", "ACTRESS", 3, "mieko_harada")]
+        [TestCase("ACTRESS:0:mieko_harada", "ACTRESS", 0, "mieko_harada")]
+        [TestCase("A1:100:mieko1", "A1", 100, "mieko1")]
+        [TestCase("A1:10000:mieko1", "A1", 10000, "mieko1")]
+        public void ParseTagIndexName_ShouldParseInput_When_InputIsValid(string input, string expectedTag, int expectedIndex, string expectedName)
+        {
+            ParseTagIndexName(input, out var tag, out var index, out var name);
+
+            Assert.AreEqual(tag, expectedTag);
+            Assert.AreEqual(index, expectedIndex);
+            Assert.AreEqual(name, expectedName);
+        }
+
+        [TestCase("")]
+        [TestCase("A")]
+        [TestCase("Aa")]
+        [TestCase("aA")]
+        [TestCase("1a")]
+        [TestCase("1")]
+        [TestCase(":name")]
+        [TestCase("A:")]
+        [TestCase("a:name")]
+        [TestCase("Aa:name")]
+        [TestCase("aA:name")]
+        [TestCase("1A:name")]
+        [TestCase("1:name")]
+        [TestCase(":1:name")]
+        [TestCase("A:1:")]
+        [TestCase("A::name")]
+        [TestCase("a:1:name")]
+        [TestCase("Aa:1:name")]
+        [TestCase("aA:1:name")]
+        [TestCase("1A:1:name")]
+        [TestCase("1:1:name")]
+        [TestCase("A:1:N")]
+        [TestCase("A:1:nN")]
+        [TestCase("A:1:Nn")]
+        [TestCase("A:1:1name")]
+        [TestCase("A:1:1")]
+        [TestCase("A:-0:name")]
+        [TestCase("A:-1:name")]
+        [TestCase("A:01:name")]
+        [TestCase("A:00:name")]
+        [TestCase("A:10001:a")]
+        [TestCase("A:1:a:")]
+        [TestCase(":A:1:a")]
+        [TestCase("A:1:a:a")]
+        [TestCase("A:1:a:A")]
+        [TestCase("A:1:a:1")]
+        public void ParseTagIndexName_ShouldThrow_When_InputIsInvalid(string input)
+        {
+            var tag = "UNTOUCHED";
+            var index = -1;
+            var name = "untouched";
+
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ParseTagIndexName(input, out tag, out index, out name); });
+            Assert.AreEqual(tag, "UNTOUCHED");
+            Assert.AreEqual(index, -1);
+            Assert.AreEqual(name, "untouched");
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void ParseTagIndexName_ShouldThrow_When_InputIncludesBadCharacters(
+          [Values('!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '{', '}', '[', ']',
+              '/', '=', '?', '+', '\\', '|', '-', ';', ':', '\'', '"', '<', '.', '>')] char ch,
+          [Values("$0", "$0a", "a$0", "$0:a", "A$0:a", "$0A:a", "A:$0:a", "A:$01:a", "A:1$0:a", "A:1:a$0", "$0A:1:a")] string str
+        )
+        {
+            ParseTagIndexName_ShouldThrow_When_InputIsInvalid(str.Replace("$0", $"{ch}"));
+        }
+        #endregion
+
+        #region .ParseTagIndex
+        [TestCase("", "", 0)]
+        [TestCase("VIDEO:0", "VIDEO", 0)]
+        [TestCase("VIDEO:1", "VIDEO", 1)]
+        [TestCase("AUDIO:2", "AUDIO", 2)]
+        [TestCase(":0", "", 0)]
+        [TestCase(":1", "", 1)]
+        [TestCase(":100", "", 100)]
+        [TestCase("VIDEO:10000", "VIDEO", 10000)]
+        public void ParseTagIndex_ShouldParseInput_When_InputIsValid(string input, string expectedTag, int expectedIndex)
+        {
+            ParseTagIndex(input, out var tag, out var index);
+
+            Assert.AreEqual(tag, expectedTag);
+            Assert.AreEqual(index, expectedIndex);
+        }
+
+        [TestCase("a")]
+        [TestCase("Aa")]
+        [TestCase("aA")]
+        [TestCase("1A")]
+        [TestCase("1")]
+        [TestCase(":")]
+        [TestCase(":a")]
+        [TestCase(":A")]
+        [TestCase(":-0")]
+        [TestCase(":-1")]
+        [TestCase(":01")]
+        [TestCase(":00")]
+        [TestCase("A:")]
+        [TestCase("A:a")]
+        [TestCase("A:A")]
+        [TestCase("A:-0")]
+        [TestCase("A:-1")]
+        [TestCase("A:01")]
+        [TestCase("A:00")]
+        [TestCase("A:10001")]
+        [TestCase("A:1:")]
+        [TestCase(":A:1")]
+        [TestCase("A:1:2")]
+        [TestCase("A:A:1")]
+        public void ParseTagIndex_ShouldThrow_When_InputIsInvalid(string input)
+        {
+            var tag = "UNTOUCHED";
+            var index = -1;
+
+#pragma warning disable IDE0058
+            Assert.Throws<ArgumentException>(() => { ParseTagIndex(input, out tag, out index); });
+            Assert.AreEqual(tag, "UNTOUCHED");
+            Assert.AreEqual(index, -1);
+#pragma warning restore IDE0058
+        }
+
+        [Test]
+        public void ParseTagIndex_ShouldThrow_When_InputIncludesBadCharacters(
+          [Values('!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '{', '}', '[', ']',
+              '/', '=', '?', '+', '\\', '|', '-', ';', ':', '\'', '"', '<', '.', '>')] char ch,
+          [Values("$0", "$0A", "A$0", "$0:1", "A$0:1", "$0A:1", "A:1$0", "A:$01")] string str
+        )
+        {
+            ParseTagIndex_ShouldThrow_When_InputIsInvalid(str.Replace("$0", $"{ch}"));
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
@@ -1,0 +1,184 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Format;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Gpu;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Mediapipe.Net.Tests.Gpu
+{
+    public class GlCalculatorHelperTest
+    {
+        #region Constructor
+        [Test, GpuOnly]
+        public void Ctor_ShouldInstantiateGlCalculatorHelper()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            Assert.AreNotEqual(glCalculatorHelper.MpPtr, IntPtr.Zero);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            Assert.False(glCalculatorHelper.IsDisposed);
+        }
+
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.Dispose();
+
+            Assert.True(glCalculatorHelper.IsDisposed);
+        }
+        #endregion
+
+        #region InitializeForTest
+        [Test, GpuOnly]
+        public void InitializeForTest_ShouldInitialize()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            Assert.False(glCalculatorHelper.Initialized());
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+            Assert.True(glCalculatorHelper.Initialized());
+        }
+        #endregion
+
+        #region RunInGlContext
+        [Test, GpuOnly]
+        public void RunInGlContext_ShouldReturnOk_When_FunctionReturnsOk()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            var status = glCalculatorHelper.RunInGlContext(() => { return Status.Ok(); });
+            Assert.True(status.Ok());
+        }
+
+        [Test, GpuOnly]
+        public void RunInGlContext_ShouldReturnInternal_When_FunctionReturnsInternal()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            var status = glCalculatorHelper.RunInGlContext(() => { return Status.Build(Status.StatusCode.Internal, "error"); });
+            Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
+        }
+
+        [Test, GpuOnly]
+        public void RunInGlContext_ShouldReturnFailedPreCondition_When_FunctionThrows()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+#pragma warning disable IDE0039
+            GlCalculatorHelper.GlStatusFunction glStatusFunction = () => { throw new InvalidProgramException(); };
+#pragma warning restore IDE0039
+            var status = glCalculatorHelper.RunInGlContext(glStatusFunction);
+            Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
+        }
+        #endregion
+
+        #region CreateSourceTexture
+        [Test, GpuOnly]
+        public void CreateSourceTexture_ShouldReturnGlTexture_When_CalledWithImageFrame()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            using var imageFrame = new ImageFrame(ImageFormat.Srgba, 32, 24);
+            var status = glCalculatorHelper.RunInGlContext(() =>
+            {
+                var texture = glCalculatorHelper.CreateSourceTexture(imageFrame);
+
+                Assert.AreEqual(texture.Width, 32);
+                Assert.AreEqual(texture.Height, 24);
+
+                texture.Dispose();
+                return Status.Ok();
+            });
+            Assert.True(status.Ok());
+
+            status.Dispose();
+        }
+
+        [Test, GpuOnly]
+        [Ignore("Skip because a thread hangs")]
+        public void CreateSourceTexture_ShouldFail_When_ImageFrameFormatIsInvalid()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            using var imageFrame = new ImageFrame(ImageFormat.Sbgra, 32, 24);
+            var status = glCalculatorHelper.RunInGlContext(() =>
+            {
+                using (var texture = glCalculatorHelper.CreateSourceTexture(imageFrame))
+                {
+                    texture.Release();
+                }
+                return Status.Ok();
+            });
+            Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
+
+            status.Dispose();
+        }
+        #endregion
+
+        #region CreateDestinationTexture
+        [Test, GpuOnly]
+        public void CreateDestinationTexture_ShouldReturnGlTexture_When_GpuBufferFormatIsValid()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            var status = glCalculatorHelper.RunInGlContext(() =>
+            {
+                var glTexture = glCalculatorHelper.CreateDestinationTexture(32, 24, GpuBufferFormat.KBgra32);
+
+                Assert.AreEqual(glTexture.Width, 32);
+                Assert.AreEqual(glTexture.Height, 24);
+                return Status.Ok();
+            });
+
+            Assert.True(status.Ok());
+        }
+        #endregion
+
+        #region Framebuffer
+        [Test, GpuOnly]
+        public void Framebuffer_ShouldReturnGLName()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            // default frame buffer
+            Assert.AreEqual(glCalculatorHelper.Framebuffer, 0);
+        }
+        #endregion
+
+        #region GetGlContext
+        [Test, GpuOnly]
+        public void GetGlContext_ShouldReturnCurrentContext()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            using var glContext = glCalculatorHelper.GetGlContext();
+
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
+                Assert.AreNotEqual(glContext.EglContext, IntPtr.Zero);
+            else if (OperatingSystem.IsMacOS())
+                Assert.AreNotEqual(glContext.NsglContext, IntPtr.Zero);
+            else if (OperatingSystem.IsIOS())
+                Assert.AreNotEqual(glContext.EaglContext, IntPtr.Zero);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using Mediapipe.Net.Framework.Port;
+using Mediapipe.Net.Gpu;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Gpu
+{
+    public class GlContextTest
+    {
+        #region GetCurrent
+        [Test, GpuOnly]
+        public void GetCurrent_ShouldReturnNull_When_CalledOutOfGlContext()
+        {
+            var glContext = GlContext.GetCurrent();
+
+            Assert.Null(glContext);
+        }
+
+        [Test, GpuOnly]
+        public void GetCurrent_ShouldReturnCurrentContext_When_CalledInGlContext()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            glCalculatorHelper.RunInGlContext(() =>
+            {
+                using var glContext = GlContext.GetCurrent();
+                Assert.NotNull(glContext);
+                Assert.True(glContext?.IsCurrent());
+                return Status.Ok();
+            }).AssertOk();
+        }
+        #endregion
+
+        #region IsCurrent
+        [Test]
+        public void IsCurrent_ShouldReturnFalse_When_CalledOutOfGlContext()
+        {
+            var glContext = getGlContext();
+
+            Assert.False(glContext.IsCurrent());
+        }
+        #endregion
+
+        #region Properties
+        [Test, GpuOnly]
+        public void ShouldReturnProperties()
+        {
+            using var glContext = getGlContext();
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
+            {
+                Assert.AreNotEqual(glContext.EglDisplay, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.EglConfig, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.EglContext, IntPtr.Zero);
+                Assert.AreEqual(glContext.GlMajorVersion, 3);
+                Assert.AreEqual(glContext.GlMinorVersion, 2);
+                Assert.AreEqual(glContext.GlFinishCount, 0);
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                Assert.AreNotEqual(glContext.NsglContext, IntPtr.Zero);
+            }
+            else if (OperatingSystem.IsIOS())
+            {
+                Assert.AreNotEqual(glContext.EaglContext, IntPtr.Zero);
+            }
+        }
+        #endregion
+
+        private static GlContext getGlContext()
+        {
+            using var glCalculatorHelper = new GlCalculatorHelper();
+            glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
+
+            return glCalculatorHelper.GetGlContext();
+        }
+    }
+}

--- a/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
@@ -37,7 +37,7 @@ namespace Mediapipe.Net.Tests.Gpu
         #endregion
 
         #region IsCurrent
-        [Test]
+        [Test, GpuOnly]
         public void IsCurrent_ShouldReturnFalse_When_CalledOutOfGlContext()
         {
             var glContext = getGlContext();

--- a/Mediapipe.Net.Tests/Gpu/GlTextureTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlTextureTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Gpu;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Gpu
+{
+    public class GlTextureTest
+    {
+        #region Constructor
+        [Test, GpuOnly]
+        public void Ctor_ShouldInstantiateGlTexture_When_CalledWithNoArguments()
+        {
+            using var glTexture = new GlTexture();
+            Assert.AreEqual(glTexture.Width, 0);
+            Assert.AreEqual(glTexture.Height, 0);
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var glTexture = new GlTexture();
+            Assert.False(glTexture.IsDisposed);
+        }
+
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var glTexture = new GlTexture();
+            glTexture.Dispose();
+
+            Assert.True(glTexture.IsDisposed);
+        }
+        #endregion
+
+        #region Target
+        [Test, GpuOnly]
+        public void Target_ShouldReturnTarget()
+        {
+            using var glTexture = new GlTexture();
+            Assert.AreEqual(glTexture.Target, Gl.GL_TEXTURE_2D);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/Gpu/GpuResourcesTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GpuResourcesTest.cs
@@ -1,0 +1,39 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Gpu;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests.Gpu
+{
+    public class GpuResourcesTest
+    {
+        #region Create
+        [Test, GpuOnly]
+        public void Create_ShouldReturnStatusOrGpuResources()
+        {
+            using var statusOrGpuResources = GpuResources.Create();
+            Assert.True(statusOrGpuResources.Ok());
+        }
+        #endregion
+
+        #region IsDisposed
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
+        {
+            using var gpuResources = GpuResources.Create().Value();
+            Assert.False(gpuResources.IsDisposed);
+        }
+
+        [Test, GpuOnly]
+        public void IsDisposed_ShouldReturnTrue_When_AlreadyDisposed()
+        {
+            var gpuResources = GpuResources.Create().Value();
+            gpuResources.Dispose();
+
+            Assert.True(gpuResources.IsDisposed);
+        }
+        #endregion
+    }
+}

--- a/Mediapipe.Net.Tests/GpuOnlyAttribute.cs
+++ b/Mediapipe.Net.Tests/GpuOnlyAttribute.cs
@@ -1,0 +1,12 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class GpuOnlyAttribute : CategoryAttribute { }
+}

--- a/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
+++ b/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
@@ -7,12 +7,17 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Package references">
+    <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
     <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project references">
+    <ProjectReference Include="..\Mediapipe.Net\Mediapipe.Net.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
+++ b/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup Label="Package references">
     <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
     <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9" />
+    <!-- <PackageReference Include="Mediapipe.Net.Runtime.GPU" Version="0.8.9" /> -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />

--- a/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
+++ b/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Mediapipe.Net.Tests/SignalAbortAttribute.cs
+++ b/Mediapipe.Net.Tests/SignalAbortAttribute.cs
@@ -1,0 +1,12 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using NUnit.Framework;
+
+namespace Mediapipe.Net.Tests
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class SignalAbortAttribute : CategoryAttribute { }
+}

--- a/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
@@ -62,7 +62,11 @@ namespace Mediapipe.Net.Gpu
                 return tmpStatus.MpPtr;
             };
 
-            var nativeGlStatusFuncHandle = GCHandle.Alloc(nativeGlStatusFunc, GCHandleType.Pinned);
+            // Was previously `GCHandleType.Pinned`. It had to be changed because
+            // the `NativeGlStatusFunction` delegate type is non-blittable.
+            // Using `GCHandleType.Normal` should be fine as it seems that all we
+            // need to do is to make sure that the delegate doesn't get garbage-collected.
+            var nativeGlStatusFuncHandle = GCHandle.Alloc(nativeGlStatusFunc, GCHandleType.Normal);
             var status = RunInGlContext(nativeGlStatusFunc);
             nativeGlStatusFuncHandle.Free();
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
@@ -10,11 +10,12 @@ namespace Mediapipe.Net.Native
 {
     internal partial class SafeNativeMethods : NativeMethods
     {
+#pragma warning disable CA2101
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__HasError(IntPtr graph);
 
-        [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__HasInputStream__PKc(IntPtr graph, string name);
 
@@ -29,5 +30,6 @@ namespace Mediapipe.Net.Native
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__UnthrottleSources(IntPtr graph);
+#pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
@@ -9,7 +9,8 @@ namespace Mediapipe.Net.Native
 {
     internal partial class UnsafeNativeMethods : NativeMethods
     {
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable CA2101
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode absl_Status__i_PKc(int code, string message, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -17,5 +18,6 @@ namespace Mediapipe.Net.Native
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode absl_Status__ToString(IntPtr status, out IntPtr str);
+#pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Glog.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Glog.cs
@@ -9,7 +9,8 @@ namespace Mediapipe.Net.Native
 {
     internal partial class UnsafeNativeMethods : NativeMethods
     {
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable CA2101
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode google_InitGoogleLogging__PKc(string name);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -24,25 +25,26 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void glog_FLAGS_minloglevel(int level);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern void glog_FLAGS_log_dir(string dir);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void glog_FLAGS_v(int v);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern void glog_LOG_INFO__PKc(string str);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern void glog_LOG_WARNING__PKc(string str);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern void glog_LOG_ERROR__PKc(string str);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern void glog_LOG_FATAL__PKc(string str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void google_FlushLogFiles(Glog.Severity severity);
+#pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
@@ -9,8 +9,10 @@ namespace Mediapipe.Net.Native
 {
     internal partial class UnsafeNativeMethods : NativeMethods
     {
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable CA2101
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_api__ConvertFromCalculatorGraphConfigTextFormat(string configText, out SerializedProto serializedProto);
+#pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -11,10 +11,11 @@ namespace Mediapipe.Net.Native
 {
     internal partial class UnsafeNativeMethods : NativeMethods
     {
+#pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__(out IntPtr graph);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__PKc(string textFormatConfig, out IntPtr graph);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -33,12 +34,12 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__Config(IntPtr graph, out SerializedProto serializedProto);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(IntPtr graph, string streamName,
             [MarshalAs(UnmanagedType.FunctionPtr)] CalculatorGraph.NativePacketCallback packetCallback,
             [MarshalAs(UnmanagedType.I1)] bool observeTimestampBounds, out IntPtr status);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__AddOutputStreamPoller__PKc_b(IntPtr graph, string streamName, [MarshalAs(UnmanagedType.I1)] bool observeTimestampBounds, out IntPtr statusOrPoller);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -53,15 +54,15 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__WaitUntilDone(IntPtr graph, out IntPtr status);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__AddPacketToInputStream__PKc_Ppacket(
             IntPtr graph, string streamName, IntPtr packet, out IntPtr status);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__SetInputStreamMaxQueueSize__PKc_i(
             IntPtr graph, string streamName, int maxQueueSize, out IntPtr status);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__CloseInputStream__PKc(IntPtr graph, string streamName, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -77,5 +78,6 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__SetGpuResources__SPgpu(IntPtr graph, IntPtr gpuResources, out IntPtr status);
         #endregion
+#pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -9,6 +9,7 @@ namespace Mediapipe.Net.Native
 {
     internal partial class UnsafeNativeMethods : NativeMethods
     {
+#pragma warning disable CA2101
         #region common
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_Packet__(out IntPtr packet);
@@ -92,10 +93,10 @@ namespace Mediapipe.Net.Native
         #endregion
 
         #region String
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp__MakeStringPacket__PKc(string value, out IntPtr packet);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp__MakeStringPacket_At__PKc_Rt(string value, IntPtr timestamp, out IntPtr packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -121,14 +122,15 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_SidePacket__delete(IntPtr sidePacket);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_SidePacket__emplace__PKc_Rp(IntPtr sidePacket, string key, IntPtr packet);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_SidePacket__at__PKc(IntPtr sidePacket, string key, out IntPtr packet);
 
-        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_SidePacket__erase__PKc(IntPtr sidePacket, string key, out int count);
         #endregion
+#pragma warning restore CA2101
     }
 }


### PR DESCRIPTION
This PR ports all tests from MediaPipeUnityPlugin.

Several things to note:

- Using `fixed` to get a pointer from a C# array and passing it as pixel data to an `ImageFrame` turned out completely fine.
- Unlike with Akihabara, the GPU side literally just works! Every single test is a success! :D
- CI has been added but only checks for the CPU side. Checking for the GPU side would require to change the reference for the appropriate `Mediapipe.Net.Runtime` package in `Mediapipe.Net.Tests.csproj`. There must be a better way to have both though, I'm just not sure what we should do for it.
- in `Mediapipe.Net/Gpu/GlCalculatorHelper.cs` in the `RunInGlContext()` method, I have replaced `GCHandleType.Pinned` with `GCHandleType.Normal`. As I've said on Discord:
  > [...] it seems that the only thing we want to do is prevent this delegate from being GC'd, which is exactly what `GCHandleType.Normal` can do
  > We just create the handle, let the managed delegate be called by `RunInGLContext` and then free the handle

Despite all this, I still want to make sure that the scope of this PR is to port the tests one-to-one and make sure that they succeed. The task of replacing some `Marshal`s with `unsafe` statements, or replace some methods with properties, are for the near future and will be in separate PRs. I'll also make sure to create issues for them beforehand (unless one of you wants to do that).