### PR TITLE
Replace slow `Marshal` operations with `unsafe`

### DIFF
--- a/Mediapipe.Net.Examples.FaceMesh/Program.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/Program.cs
@@ -17,9 +17,7 @@ namespace Mediapipe.Net.Examples.FaceMesh
     public static class Program
     {
         private static Camera? camera;
-
         private static FrameConverter? converter;
-
         private static FaceMeshCpuCalculator? calculator;
 
         public static void Main(string[] args)
@@ -76,11 +74,11 @@ namespace Mediapipe.Net.Examples.FaceMesh
             ImageFrame imgframe;
             fixed (byte* rawDataPtr = cFrame.RawData)
             {
-                imgframe = new ImageFrame(ImageFormat.Srgba, cFrame.Width, cFrame.Height, cFrame.WidthStep,
-                    rawDataPtr);
+                imgframe = new ImageFrame(ImageFormat.Srgba,
+                    cFrame.Width, cFrame.Height, cFrame.WidthStep, rawDataPtr);
             }
 
-            ImageFrame img = calculator.Send(imgframe);
+            using ImageFrame img = calculator.Send(imgframe);
             imgframe.Dispose();
         }
 

--- a/Mediapipe.Net.Examples.FaceMeshGpu/Program.cs
+++ b/Mediapipe.Net.Examples.FaceMeshGpu/Program.cs
@@ -79,6 +79,7 @@ namespace Mediapipe.Net.Examples.FaceMeshGpu
                 imgframe = new ImageFrame(ImageFormat.Srgba,
                     cFrame.Width, cFrame.Height, cFrame.WidthStep, rawDataPtr);
             }
+
             using ImageFrame img = calculator.Send(imgframe);
             imgframe.Dispose();
         }

--- a/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
+++ b/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
@@ -74,7 +74,7 @@ namespace Mediapipe.Net.Examples.OsuFrameworkVisualTests
             using ImageFrame outImgFrame = calculator.Send(imgFrame);
             imgFrame.Dispose();
 
-            var span = new ReadOnlySpan<byte>((byte*)outImgFrame.MutablePixelData, outImgFrame.Height * outImgFrame.WidthStep);
+            var span = new ReadOnlySpan<byte>(outImgFrame.MutablePixelData, outImgFrame.Height * outImgFrame.WidthStep);
             var pixelData = SixLabors.ImageSharp.Image.LoadPixelData<Rgba32>(span, cFrame.Width, cFrame.Height);
 
             texture ??= new Texture(cFrame.Width, cFrame.Height);

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -31,7 +31,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.True(imageFrame.IsEmpty);
             Assert.False(imageFrame.IsContiguous);
             Assert.False(imageFrame.IsAligned(16));
-            Assert.AreEqual(imageFrame.MutablePixelData, void*.Zero);
+            Assert.AreEqual(imageFrame.MutablePixelData, null);
 #pragma warning restore IDE0058
         }
 
@@ -51,7 +51,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.False(imageFrame.IsEmpty);
             Assert.True(imageFrame.IsContiguous);
             Assert.True(imageFrame.IsAligned(16));
-            Assert.AreNotEqual(imageFrame.MutablePixelData, void*.Zero);
+            Assert.AreNotEqual(imageFrame.MutablePixelData, null);
         }
 
         [Test]

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -31,7 +31,10 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.True(imageFrame.IsEmpty);
             Assert.False(imageFrame.IsContiguous);
             Assert.False(imageFrame.IsAligned(16));
-            Assert.AreEqual(imageFrame.MutablePixelData, null);
+            unsafe
+            {
+                Assert.True(imageFrame.MutablePixelData == null);
+            }
 #pragma warning restore IDE0058
         }
 
@@ -51,7 +54,10 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.False(imageFrame.IsEmpty);
             Assert.True(imageFrame.IsContiguous);
             Assert.True(imageFrame.IsAligned(16));
-            Assert.AreNotEqual(imageFrame.MutablePixelData, null);
+            unsafe
+            {
+                Assert.True(imageFrame.MutablePixelData != null);
+            }
         }
 
         [Test]

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -91,7 +91,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
         }
 
         [Test, SignalAbort]
-        public void Ctor_ShouldThrowMediaPipeException_When_CalledWithInvalidArgument()
+        public void Ctor_ShouldThrowMediapipeException_When_CalledWithInvalidArgument()
         {
 #pragma warning disable IDE0058
             Assert.Throws<MediapipeException>(() => { new ImageFrame(ImageFormat.Sbgra, 640, 480, 0); });

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -31,7 +31,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.True(imageFrame.IsEmpty);
             Assert.False(imageFrame.IsContiguous);
             Assert.False(imageFrame.IsAligned(16));
-            Assert.AreEqual(imageFrame.MutablePixelData, IntPtr.Zero);
+            Assert.AreEqual(imageFrame.MutablePixelData, void*.Zero);
 #pragma warning restore IDE0058
         }
 
@@ -51,7 +51,7 @@ namespace Mediapipe.Net.Tests.Framework.Format
             Assert.False(imageFrame.IsEmpty);
             Assert.True(imageFrame.IsContiguous);
             Assert.True(imageFrame.IsAligned(16));
-            Assert.AreNotEqual(imageFrame.MutablePixelData, IntPtr.Zero);
+            Assert.AreNotEqual(imageFrame.MutablePixelData, void*.Zero);
         }
 
         [Test]

--- a/Mediapipe.Net.Tests/Framework/Packet/ImageFramePacketTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Packet/ImageFramePacketTest.cs
@@ -81,7 +81,7 @@ namespace Mediapipe.Net.Tests.Framework.Packet
 
         #region Get
         [Test, SignalAbort]
-        public void Get_ShouldThrowMediaPipeException_When_DataIsEmpty()
+        public void Get_ShouldThrowMediapipeException_When_DataIsEmpty()
         {
             using var packet = new ImageFramePacket();
 #pragma warning disable IDE0058

--- a/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
@@ -18,7 +18,7 @@ namespace Mediapipe.Net.Tests.Gpu
         public void Ctor_ShouldInstantiateGlCalculatorHelper()
         {
             using var glCalculatorHelper = new GlCalculatorHelper();
-            Assert.AreNotEqual(glCalculatorHelper.MpPtr, void*.Zero);
+            Assert.AreNotEqual(glCalculatorHelper.MpPtr, null);
         }
         #endregion
 
@@ -173,11 +173,11 @@ namespace Mediapipe.Net.Tests.Gpu
             using var glContext = glCalculatorHelper.GetGlContext();
 
             if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
-                Assert.AreNotEqual(glContext.EglContext, void*.Zero);
+                Assert.AreNotEqual(glContext.EglContext, null);
             else if (OperatingSystem.IsMacOS())
-                Assert.AreNotEqual(glContext.NsglContext, void*.Zero);
+                Assert.AreNotEqual(glContext.NsglContext, null);
             else if (OperatingSystem.IsIOS())
-                Assert.AreNotEqual(glContext.EaglContext, void*.Zero);
+                Assert.AreNotEqual(glContext.EaglContext, null);
         }
         #endregion
     }

--- a/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
@@ -113,7 +113,6 @@ namespace Mediapipe.Net.Tests.Gpu
         }
 
         [Test, GpuOnly]
-        [Ignore("Skip because a thread hangs")]
         public void CreateSourceTexture_ShouldFail_When_ImageFrameFormatIsInvalid()
         {
             using var glCalculatorHelper = new GlCalculatorHelper();

--- a/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
@@ -18,7 +18,7 @@ namespace Mediapipe.Net.Tests.Gpu
         public void Ctor_ShouldInstantiateGlCalculatorHelper()
         {
             using var glCalculatorHelper = new GlCalculatorHelper();
-            Assert.AreNotEqual(glCalculatorHelper.MpPtr, IntPtr.Zero);
+            Assert.AreNotEqual(glCalculatorHelper.MpPtr, void*.Zero);
         }
         #endregion
 
@@ -173,11 +173,11 @@ namespace Mediapipe.Net.Tests.Gpu
             using var glContext = glCalculatorHelper.GetGlContext();
 
             if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
-                Assert.AreNotEqual(glContext.EglContext, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.EglContext, void*.Zero);
             else if (OperatingSystem.IsMacOS())
-                Assert.AreNotEqual(glContext.NsglContext, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.NsglContext, void*.Zero);
             else if (OperatingSystem.IsIOS())
-                Assert.AreNotEqual(glContext.EaglContext, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.EaglContext, void*.Zero);
         }
         #endregion
     }

--- a/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlCalculatorHelperTest.cs
@@ -18,7 +18,10 @@ namespace Mediapipe.Net.Tests.Gpu
         public void Ctor_ShouldInstantiateGlCalculatorHelper()
         {
             using var glCalculatorHelper = new GlCalculatorHelper();
-            Assert.AreNotEqual(glCalculatorHelper.MpPtr, null);
+            unsafe
+            {
+                Assert.True(glCalculatorHelper.MpPtr != null);
+            }
         }
         #endregion
 
@@ -172,12 +175,15 @@ namespace Mediapipe.Net.Tests.Gpu
 
             using var glContext = glCalculatorHelper.GetGlContext();
 
-            if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
-                Assert.AreNotEqual(glContext.EglContext, null);
-            else if (OperatingSystem.IsMacOS())
-                Assert.AreNotEqual(glContext.NsglContext, null);
-            else if (OperatingSystem.IsIOS())
-                Assert.AreNotEqual(glContext.EaglContext, null);
+            unsafe
+            {
+                if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
+                    Assert.True(glContext.EglContext != null);
+                else if (OperatingSystem.IsMacOS())
+                    Assert.True(glContext.NsglContext != null);
+                else if (OperatingSystem.IsIOS())
+                    Assert.True(glContext.EaglContext != null);
+            }
         }
         #endregion
     }

--- a/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
@@ -53,20 +53,20 @@ namespace Mediapipe.Net.Tests.Gpu
             using var glContext = getGlContext();
             if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
             {
-                Assert.AreNotEqual(glContext.EglDisplay, void*.Zero);
-                Assert.AreNotEqual(glContext.EglConfig, void*.Zero);
-                Assert.AreNotEqual(glContext.EglContext, void*.Zero);
+                Assert.AreNotEqual(glContext.EglDisplay, null);
+                Assert.AreNotEqual(glContext.EglConfig, null);
+                Assert.AreNotEqual(glContext.EglContext, null);
                 Assert.AreEqual(glContext.GlMajorVersion, 3);
                 Assert.AreEqual(glContext.GlMinorVersion, 2);
                 Assert.AreEqual(glContext.GlFinishCount, 0);
             }
             else if (OperatingSystem.IsMacOS())
             {
-                Assert.AreNotEqual(glContext.NsglContext, void*.Zero);
+                Assert.AreNotEqual(glContext.NsglContext, null);
             }
             else if (OperatingSystem.IsIOS())
             {
-                Assert.AreNotEqual(glContext.EaglContext, void*.Zero);
+                Assert.AreNotEqual(glContext.EaglContext, null);
             }
         }
         #endregion

--- a/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
@@ -48,25 +48,25 @@ namespace Mediapipe.Net.Tests.Gpu
 
         #region Properties
         [Test, GpuOnly]
-        public void ShouldReturnProperties()
+        public unsafe void ShouldReturnProperties()
         {
             using var glContext = getGlContext();
             if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
             {
-                Assert.AreNotEqual(glContext.EglDisplay, null);
-                Assert.AreNotEqual(glContext.EglConfig, null);
-                Assert.AreNotEqual(glContext.EglContext, null);
+                Assert.True(glContext.EglDisplay != null);
+                Assert.True(glContext.EglConfig != null);
+                Assert.True(glContext.EglContext != null);
                 Assert.AreEqual(glContext.GlMajorVersion, 3);
                 Assert.AreEqual(glContext.GlMinorVersion, 2);
                 Assert.AreEqual(glContext.GlFinishCount, 0);
             }
             else if (OperatingSystem.IsMacOS())
             {
-                Assert.AreNotEqual(glContext.NsglContext, null);
+                Assert.True(glContext.NsglContext != null);
             }
             else if (OperatingSystem.IsIOS())
             {
-                Assert.AreNotEqual(glContext.EaglContext, null);
+                Assert.True(glContext.EaglContext != null);
             }
         }
         #endregion

--- a/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
+++ b/Mediapipe.Net.Tests/Gpu/GlContextTest.cs
@@ -53,20 +53,20 @@ namespace Mediapipe.Net.Tests.Gpu
             using var glContext = getGlContext();
             if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
             {
-                Assert.AreNotEqual(glContext.EglDisplay, IntPtr.Zero);
-                Assert.AreNotEqual(glContext.EglConfig, IntPtr.Zero);
-                Assert.AreNotEqual(glContext.EglContext, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.EglDisplay, void*.Zero);
+                Assert.AreNotEqual(glContext.EglConfig, void*.Zero);
+                Assert.AreNotEqual(glContext.EglContext, void*.Zero);
                 Assert.AreEqual(glContext.GlMajorVersion, 3);
                 Assert.AreEqual(glContext.GlMinorVersion, 2);
                 Assert.AreEqual(glContext.GlFinishCount, 0);
             }
             else if (OperatingSystem.IsMacOS())
             {
-                Assert.AreNotEqual(glContext.NsglContext, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.NsglContext, void*.Zero);
             }
             else if (OperatingSystem.IsIOS())
             {
-                Assert.AreNotEqual(glContext.EaglContext, IntPtr.Zero);
+                Assert.AreNotEqual(glContext.EaglContext, void*.Zero);
             }
         }
         #endregion

--- a/Mediapipe.Net/Calculators/GpuCalculator.cs
+++ b/Mediapipe.Net/Calculators/GpuCalculator.cs
@@ -63,7 +63,10 @@ namespace Mediapipe.Net.Calculators
                 outFrame = new ImageFrame(outBuffer.Format.ImageFormatFor(), outBuffer.Width, outBuffer.Height, ImageFrame.GlDefaultAlignmentBoundary);
                 gpuHelper.BindFramebuffer(texture);
                 GlTextureInfo info = outBuffer.Format.GlTextureInfoFor(0);
-                Gl.ReadPixels(0, 0, texture.Width, texture.Height, info.GlFormat, info.GlType, outFrame.MutablePixelData);
+                unsafe
+                {
+                    Gl.ReadPixels(0, 0, texture.Width, texture.Height, info.GlFormat, info.GlType, outFrame.MutablePixelData);
+                }
                 Gl.Flush();
                 texture.Release();
 

--- a/Mediapipe.Net/Core/IMpResourceHandle.cs
+++ b/Mediapipe.Net/Core/IMpResourceHandle.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Mediapipe.Net.Core
 {
-    public interface IMpResourceHandle : IDisposable
+    public unsafe interface IMpResourceHandle : IDisposable
     {
         void* MpPtr { get; }
 

--- a/Mediapipe.Net/Core/IMpResourceHandle.cs
+++ b/Mediapipe.Net/Core/IMpResourceHandle.cs
@@ -8,7 +8,7 @@ namespace Mediapipe.Net.Core
 {
     public interface IMpResourceHandle : IDisposable
     {
-        IntPtr MpPtr { get; }
+        void* MpPtr { get; }
 
         /// <summary>
         /// Relinquish the ownership, and release the resource it owns if necessary.

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -9,7 +9,7 @@ using static Mediapipe.Net.Native.MpReturnCodeExtension;
 
 namespace Mediapipe.Net.Core
 {
-    public abstract class MpResourceHandle : Disposable, IMpResourceHandle
+    public unsafe abstract class MpResourceHandle : Disposable, IMpResourceHandle
     {
         protected void* Ptr;
 

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -68,7 +68,7 @@ namespace Mediapipe.Net.Core
             func(MpPtr, out void* strPtr).Assert();
             GC.KeepAlive(this);
 
-            string? str = Marshal.PtrToStringAnsi(strPtr);
+            string? str = Marshal.PtrToStringAnsi((IntPtr)strPtr);
             UnsafeNativeMethods.delete_array__PKc(strPtr);
 
             return str;

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -3,7 +3,6 @@
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
 using System;
-using System.Runtime.InteropServices;
 using Mediapipe.Net.Native;
 using static Mediapipe.Net.Native.MpReturnCodeExtension;
 

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Core
     {
         protected void* Ptr;
 
-        protected MpResourceHandle(bool isOwner = true) : this(void*.Zero, isOwner) { }
+        protected MpResourceHandle(bool isOwner = true) : this(null, isOwner) { }
 
         protected MpResourceHandle(void* ptr, bool isOwner = true) : base(isOwner)
         {
@@ -38,7 +38,7 @@ namespace Mediapipe.Net.Core
             TransferOwnership();
         }
 
-        public bool OwnsResource => IsOwner && Ptr != void*.Zero;
+        public bool OwnsResource => IsOwner && Ptr != null;
         #endregion
 
         protected override void DisposeUnmanaged()
@@ -54,7 +54,7 @@ namespace Mediapipe.Net.Core
         /// Forgets the pointer address.
         /// After calling this method, <see ref="OwnsResource" /> will return false.
         /// </summary>
-        protected void ReleaseMpPtr() => Ptr = void*.Zero;
+        protected void ReleaseMpPtr() => Ptr = null;
 
         /// <summary>
         /// Release the memory (call `delete` or `delete[]`) whether or not it owns it.

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -61,13 +61,13 @@ namespace Mediapipe.Net.Core
         /// <remarks>In most cases, this method should not be called directly.</remarks>
         protected abstract void DeleteMpPtr();
 
-        protected delegate MpReturnCode StringOutFunc(void* ptr, out void* strPtr);
+        protected delegate MpReturnCode StringOutFunc(void* ptr, out sbyte* strPtr);
         protected string? MarshalStringFromNative(StringOutFunc func)
         {
-            func(MpPtr, out void* strPtr).Assert();
+            func(MpPtr, out sbyte* strPtr).Assert();
             GC.KeepAlive(this);
 
-            string? str = new string((sbyte*)strPtr);
+            string? str = new string(strPtr);
             UnsafeNativeMethods.delete_array__PKc(strPtr);
 
             return str;

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -68,7 +68,7 @@ namespace Mediapipe.Net.Core
             func(MpPtr, out void* strPtr).Assert();
             GC.KeepAlive(this);
 
-            string? str = Marshal.PtrToStringAnsi((IntPtr)strPtr);
+            string? str = new string((sbyte*)strPtr);
             UnsafeNativeMethods.delete_array__PKc(strPtr);
 
             return str;

--- a/Mediapipe.Net/Core/MpResourceHandle.cs
+++ b/Mediapipe.Net/Core/MpResourceHandle.cs
@@ -11,17 +11,17 @@ namespace Mediapipe.Net.Core
 {
     public abstract class MpResourceHandle : Disposable, IMpResourceHandle
     {
-        protected IntPtr Ptr;
+        protected void* Ptr;
 
-        protected MpResourceHandle(bool isOwner = true) : this(IntPtr.Zero, isOwner) { }
+        protected MpResourceHandle(bool isOwner = true) : this(void*.Zero, isOwner) { }
 
-        protected MpResourceHandle(IntPtr ptr, bool isOwner = true) : base(isOwner)
+        protected MpResourceHandle(void* ptr, bool isOwner = true) : base(isOwner)
         {
             Ptr = ptr;
         }
 
         #region IMpResourceHandle
-        public IntPtr MpPtr
+        public void* MpPtr
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Mediapipe.Net.Core
             TransferOwnership();
         }
 
-        public bool OwnsResource => IsOwner && Ptr != IntPtr.Zero;
+        public bool OwnsResource => IsOwner && Ptr != void*.Zero;
         #endregion
 
         protected override void DisposeUnmanaged()
@@ -54,7 +54,7 @@ namespace Mediapipe.Net.Core
         /// Forgets the pointer address.
         /// After calling this method, <see ref="OwnsResource" /> will return false.
         /// </summary>
-        protected void ReleaseMpPtr() => Ptr = IntPtr.Zero;
+        protected void ReleaseMpPtr() => Ptr = void*.Zero;
 
         /// <summary>
         /// Release the memory (call `delete` or `delete[]`) whether or not it owns it.
@@ -62,10 +62,10 @@ namespace Mediapipe.Net.Core
         /// <remarks>In most cases, this method should not be called directly.</remarks>
         protected abstract void DeleteMpPtr();
 
-        protected delegate MpReturnCode StringOutFunc(IntPtr ptr, out IntPtr strPtr);
+        protected delegate MpReturnCode StringOutFunc(void* ptr, out void* strPtr);
         protected string? MarshalStringFromNative(StringOutFunc func)
         {
-            func(MpPtr, out IntPtr strPtr).Assert();
+            func(MpPtr, out void* strPtr).Assert();
             GC.KeepAlive(this);
 
             string? str = Marshal.PtrToStringAnsi(strPtr);

--- a/Mediapipe.Net/Core/SharedPtrHandle.cs
+++ b/Mediapipe.Net/Core/SharedPtrHandle.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Mediapipe.Net.Core
 {
-    public abstract class SharedPtrHandle : MpResourceHandle
+    public unsafe abstract class SharedPtrHandle : MpResourceHandle
     {
         protected SharedPtrHandle(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 

--- a/Mediapipe.Net/Core/SharedPtrHandle.cs
+++ b/Mediapipe.Net/Core/SharedPtrHandle.cs
@@ -2,8 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
-
 namespace Mediapipe.Net.Core
 {
     public unsafe abstract class SharedPtrHandle : MpResourceHandle

--- a/Mediapipe.Net/Core/SharedPtrHandle.cs
+++ b/Mediapipe.Net/Core/SharedPtrHandle.cs
@@ -8,10 +8,10 @@ namespace Mediapipe.Net.Core
 {
     public abstract class SharedPtrHandle : MpResourceHandle
     {
-        protected SharedPtrHandle(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        protected SharedPtrHandle(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         /// <returns>The owning pointer</returns>
-        public abstract IntPtr Get();
+        public abstract void* Get();
 
         /// <summary>Release the owning pointer</summary>
         public abstract void Reset();

--- a/Mediapipe.Net/Core/UniquePtrHandle.cs
+++ b/Mediapipe.Net/Core/UniquePtrHandle.cs
@@ -8,12 +8,12 @@ namespace Mediapipe.Net.Core
 {
     public abstract class UniquePtrHandle : MpResourceHandle
     {
-        protected UniquePtrHandle(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        protected UniquePtrHandle(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         /// <returns>The owning pointer</returns>
-        public abstract IntPtr Get();
+        public abstract void* Get();
 
         /// <summary>Release the owning pointer</summary>
-        public abstract IntPtr Release();
+        public abstract void* Release();
     }
 }

--- a/Mediapipe.Net/Core/UniquePtrHandle.cs
+++ b/Mediapipe.Net/Core/UniquePtrHandle.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Mediapipe.Net.Core
 {
-    public abstract class UniquePtrHandle : MpResourceHandle
+    public unsafe abstract class UniquePtrHandle : MpResourceHandle
     {
         protected UniquePtrHandle(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 

--- a/Mediapipe.Net/Core/UniquePtrHandle.cs
+++ b/Mediapipe.Net/Core/UniquePtrHandle.cs
@@ -2,8 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
-
 namespace Mediapipe.Net.Core
 {
     public unsafe abstract class UniquePtrHandle : MpResourceHandle

--- a/Mediapipe.Net/External/SerializedProto.cs
+++ b/Mediapipe.Net/External/SerializedProto.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using Google.Protobuf;
 using Mediapipe.Net.Native;
@@ -12,7 +11,7 @@ namespace Mediapipe.Net.External
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct SerializedProto
     {
-        public void* StrPtr;
+        public sbyte* StrPtr;
         public int Length;
 
         // TODO: That Dispose() method is looking very sus...
@@ -22,7 +21,8 @@ namespace Mediapipe.Net.External
         public T Deserialize<T>(MessageParser<T> parser) where T : IMessage<T>
         {
             byte[] bytes = new byte[Length];
-            Marshal.Copy((IntPtr)StrPtr, bytes, 0, bytes.Length);
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = (byte)StrPtr[i];
             return parser.ParseFrom(bytes);
         }
     }

--- a/Mediapipe.Net/External/SerializedProto.cs
+++ b/Mediapipe.Net/External/SerializedProto.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.External
     [StructLayout(LayoutKind.Sequential)]
     internal struct SerializedProto
     {
-        public IntPtr StrPtr;
+        public void* StrPtr;
         public int Length;
 
         // TODO: That Dispose() method is looking very sus...

--- a/Mediapipe.Net/External/SerializedProto.cs
+++ b/Mediapipe.Net/External/SerializedProto.cs
@@ -5,6 +5,7 @@
 using System.Runtime.InteropServices;
 using Google.Protobuf;
 using Mediapipe.Net.Native;
+using Mediapipe.Net.Util;
 
 namespace Mediapipe.Net.External
 {
@@ -20,9 +21,7 @@ namespace Mediapipe.Net.External
 
         public T Deserialize<T>(MessageParser<T> parser) where T : IMessage<T>
         {
-            byte[] bytes = new byte[Length];
-            for (int i = 0; i < bytes.Length; i++)
-                bytes[i] = (byte)StrPtr[i];
+            byte[] bytes = UnsafeUtil.SafeArrayCopy((byte*)StrPtr, Length);
             return parser.ParseFrom(bytes);
         }
     }

--- a/Mediapipe.Net/External/SerializedProto.cs
+++ b/Mediapipe.Net/External/SerializedProto.cs
@@ -22,7 +22,7 @@ namespace Mediapipe.Net.External
         public T Deserialize<T>(MessageParser<T> parser) where T : IMessage<T>
         {
             byte[] bytes = new byte[Length];
-            Marshal.Copy(StrPtr, bytes, 0, bytes.Length);
+            Marshal.Copy((IntPtr)StrPtr, bytes, 0, bytes.Length);
             return parser.ParseFrom(bytes);
         }
     }

--- a/Mediapipe.Net/External/SerializedProto.cs
+++ b/Mediapipe.Net/External/SerializedProto.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 namespace Mediapipe.Net.External
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct SerializedProto
+    internal unsafe struct SerializedProto
     {
         public void* StrPtr;
         public int Length;

--- a/Mediapipe.Net/External/SerializedProtoVector.cs
+++ b/Mediapipe.Net/External/SerializedProtoVector.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Google.Protobuf;

--- a/Mediapipe.Net/External/SerializedProtoVector.cs
+++ b/Mediapipe.Net/External/SerializedProtoVector.cs
@@ -24,16 +24,9 @@ namespace Mediapipe.Net.External
         {
             var protos = new List<T>(Size);
 
-            unsafe
-            {
-                var protoPtr = (SerializedProto*)Data;
-
-                for (var i = 0; i < Size; i++)
-                {
-                    var serializedProto = Marshal.PtrToStructure<SerializedProto>((void*)protoPtr++);
-                    protos.Add(serializedProto.Deserialize(parser));
-                }
-            }
+            var protoPtr = (SerializedProto*)Data;
+            for (var i = 0; i < Size; i++)
+                protos.Add((*protoPtr++).Deserialize(parser));
 
             return protos;
         }

--- a/Mediapipe.Net/External/SerializedProtoVector.cs
+++ b/Mediapipe.Net/External/SerializedProtoVector.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.External
     [StructLayout(LayoutKind.Sequential)]
     internal struct SerializedProtoVector
     {
-        public IntPtr Data;
+        public void* Data;
         public int Size;
 
         // TODO: This is looking just as sus as SerializedProto.Dispose().
@@ -30,7 +30,7 @@ namespace Mediapipe.Net.External
 
                 for (var i = 0; i < Size; i++)
                 {
-                    var serializedProto = Marshal.PtrToStructure<SerializedProto>((IntPtr)protoPtr++);
+                    var serializedProto = Marshal.PtrToStructure<SerializedProto>((void*)protoPtr++);
                     protos.Add(serializedProto.Deserialize(parser));
                 }
             }

--- a/Mediapipe.Net/External/SerializedProtoVector.cs
+++ b/Mediapipe.Net/External/SerializedProtoVector.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.External
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct SerializedProtoVector
     {
-        public void* Data;
+        public SerializedProto* Data;
         public int Size;
 
         // TODO: This is looking just as sus as SerializedProto.Dispose().
@@ -23,9 +23,8 @@ namespace Mediapipe.Net.External
         {
             var protos = new List<T>(Size);
 
-            var protoPtr = (SerializedProto*)Data;
-            for (var i = 0; i < Size; i++)
-                protos.Add((*protoPtr++).Deserialize(parser));
+            for (int i = 0; i < Size; i++)
+                protos.Add(Data[i].Deserialize(parser));
 
             return protos;
         }

--- a/Mediapipe.Net/External/SerializedProtoVector.cs
+++ b/Mediapipe.Net/External/SerializedProtoVector.cs
@@ -22,7 +22,6 @@ namespace Mediapipe.Net.External
         public List<T> Deserialize<T>(MessageParser<T> parser) where T : IMessage<T>
         {
             var protos = new List<T>(Size);
-
             for (int i = 0; i < Size; i++)
                 protos.Add(Data[i].Deserialize(parser));
 

--- a/Mediapipe.Net/External/SerializedProtoVector.cs
+++ b/Mediapipe.Net/External/SerializedProtoVector.cs
@@ -11,7 +11,7 @@ using Mediapipe.Net.Native;
 namespace Mediapipe.Net.External
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct SerializedProtoVector
+    internal unsafe struct SerializedProtoVector
     {
         public void* Data;
         public int Size;

--- a/Mediapipe.Net/External/StdString.cs
+++ b/Mediapipe.Net/External/StdString.cs
@@ -18,7 +18,7 @@ namespace Mediapipe.Net.External
             Ptr = ptr;
         }
 
-        protected override void DeleteMpPtr() => UnsafeNativeMethods.std_string__delete(Ptr);
+        protected override void DeleteMpPtr() => UnsafeNativeMethods.std_string__delete((sbyte*)Ptr);
 
         public void Swap(StdString str)
         {

--- a/Mediapipe.Net/External/StdString.cs
+++ b/Mediapipe.Net/External/StdString.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.External
 {
     public class StdString : MpResourceHandle
     {
-        public StdString(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public StdString(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public StdString(byte[] bytes) : base()
         {

--- a/Mediapipe.Net/External/StdString.cs
+++ b/Mediapipe.Net/External/StdString.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.External
 {
-    public class StdString : MpResourceHandle
+    public unsafe class StdString : MpResourceHandle
     {
         public StdString(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 

--- a/Mediapipe.Net/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraph.cs
@@ -15,7 +15,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework
 {
-    public class CalculatorGraph : MpResourceHandle
+    public unsafe class CalculatorGraph : MpResourceHandle
     {
         public delegate void* NativePacketCallback(void* graphPtr, void* packetPtr);
         public delegate Status PacketCallback<TPacket, TValue>(TPacket? packet) where TPacket : Packet<TValue>;

--- a/Mediapipe.Net/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraph.cs
@@ -17,7 +17,7 @@ namespace Mediapipe.Net.Framework
 {
     public class CalculatorGraph : MpResourceHandle
     {
-        public delegate IntPtr NativePacketCallback(IntPtr graphPtr, IntPtr packetPtr);
+        public delegate void* NativePacketCallback(void* graphPtr, void* packetPtr);
         public delegate Status PacketCallback<TPacket, TValue>(TPacket? packet) where TPacket : Packet<TValue>;
 
         public CalculatorGraph() : base()

--- a/Mediapipe.Net/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraph.cs
@@ -150,7 +150,7 @@ namespace Mediapipe.Net.Framework
             return new Status(statusPtr);
         }
 
-        public bool HasError() => SafeNativeMethods.mp_CalculatorGraph__HasError(MpPtr);
+        public bool HasError() => SafeNativeMethods.mp_CalculatorGraph__HasError(MpPtr) > 0;
 
         public Status AddPacketToInputStream<T>(string streamName, Packet<T> packet)
         {
@@ -191,11 +191,11 @@ namespace Mediapipe.Net.Framework
             GC.KeepAlive(this);
         }
 
-        public bool GraphInputStreamsClosed() => SafeNativeMethods.mp_CalculatorGraph__GraphInputStreamsClosed(MpPtr);
+        public bool GraphInputStreamsClosed() => SafeNativeMethods.mp_CalculatorGraph__GraphInputStreamsClosed(MpPtr) > 0;
 
-        public bool IsNodeThrottled(int nodeId) => SafeNativeMethods.mp_CalculatorGraph__IsNodeThrottled__i(MpPtr, nodeId);
+        public bool IsNodeThrottled(int nodeId) => SafeNativeMethods.mp_CalculatorGraph__IsNodeThrottled__i(MpPtr, nodeId) > 0;
 
-        public bool UnthrottleSources() => SafeNativeMethods.mp_CalculatorGraph__UnthrottleSources(MpPtr);
+        public bool UnthrottleSources() => SafeNativeMethods.mp_CalculatorGraph__UnthrottleSources(MpPtr) > 0;
 
         public GpuResources GetGpuResources()
         {

--- a/Mediapipe.Net/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraph.cs
@@ -87,7 +87,7 @@ namespace Mediapipe.Net.Framework
                 Status status;
                 try
                 {
-                    var packet = (TPacket?)Activator.CreateInstance(typeof(TPacket), packetPtr, false);
+                    var packet = (TPacket?)Activator.CreateInstance(typeof(TPacket), (IntPtr)packetPtr, false);
                     status = packetCallback(packet);
                 }
                 catch (Exception e)

--- a/Mediapipe.Net/Framework/CalculatorGraphConfigExtension.cs
+++ b/Mediapipe.Net/Framework/CalculatorGraphConfigExtension.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework
     {
         public static CalculatorGraphConfig ParseFromTextFormat(this MessageParser<CalculatorGraphConfig> _, string configText)
         {
-            if (UnsafeNativeMethods.mp_api__ConvertFromCalculatorGraphConfigTextFormat(configText, out var serializedProto))
+            if (UnsafeNativeMethods.mp_api__ConvertFromCalculatorGraphConfigTextFormat(configText, out var serializedProto) > 0)
             {
                 var config = serializedProto.Deserialize(CalculatorGraphConfig.Parser);
                 serializedProto.Dispose();

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -242,9 +242,9 @@ namespace Mediapipe.Net.Framework.Format
                     {
                         var pDest = dest + colors.Length - 1;
 
-                        for (var i = 0; i < height; i++)
+                        for (int i = 0; i < height; i++)
                         {
-                            for (var j = 0; j < width; j++)
+                            for (int j = 0; j < width; j++)
                             {
                                 *pDest-- = *pSrc;
                                 pSrc += channelCount;
@@ -256,9 +256,9 @@ namespace Mediapipe.Net.Framework.Format
                     {
                         var pDest = dest + width * (height - 1);
 
-                        for (var i = 0; i < height; i++)
+                        for (int i = 0; i < height; i++)
                         {
-                            for (var j = 0; j < width; j++)
+                            for (int j = 0; j < width; j++)
                             {
                                 *pDest++ = *pSrc;
                                 pSrc += channelCount;

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -235,7 +235,7 @@ namespace Mediapipe.Net.Framework.Format
             {
                 fixed (byte* dest = colors)
                 {
-                    var pSrc = (byte*)ptr.ToPointer();
+                    var pSrc = (byte*)ptr;
                     pSrc += channelNumber;
 
                     if (flipVertically)

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Format
         public static readonly uint DefaultAlignmentBoundary = 16;
         public static readonly uint GlDefaultAlignmentBoundary = 4;
 
-        public delegate void Deleter(IntPtr ptr);
+        public delegate void Deleter(void* ptr);
 
         public ImageFrame() : base()
         {
@@ -21,7 +21,7 @@ namespace Mediapipe.Net.Framework.Format
             Ptr = ptr;
         }
 
-        public ImageFrame(IntPtr imageFramePtr, bool isOwner = true) : base(imageFramePtr, isOwner) { }
+        public ImageFrame(void* imageFramePtr, bool isOwner = true) : base(imageFramePtr, isOwner) { }
 
         public ImageFrame(ImageFormat format, int width, int height) : this(format, width, height, DefaultAlignmentBoundary) { }
 
@@ -43,7 +43,7 @@ namespace Mediapipe.Net.Framework.Format
         {
             UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
                 format, width, height, widthStep,
-                (IntPtr)pixelData,
+                (void*)pixelData,
                 releasePixelData,
                 out var ptr).Assert();
             Ptr = ptr;
@@ -52,7 +52,7 @@ namespace Mediapipe.Net.Framework.Format
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_ImageFrame__delete(Ptr);
 
         // [AOT.MonoPInvokeCallback(typeof(Deleter))] (?)
-        private static void releasePixelData(IntPtr ptr)
+        private static void releasePixelData(void* ptr)
         {
             // Do nothing (pixelData is moved)
         }
@@ -110,7 +110,7 @@ namespace Mediapipe.Net.Framework.Format
 
         public int WidthStep => SafeNativeMethods.mp_ImageFrame__WidthStep(MpPtr);
 
-        public IntPtr MutablePixelData => SafeNativeMethods.mp_ImageFrame__MutablePixelData(MpPtr);
+        public void* MutablePixelData => SafeNativeMethods.mp_ImageFrame__MutablePixelData(MpPtr);
 
         public int PixelDataSize => SafeNativeMethods.mp_ImageFrame__PixelDataSize(MpPtr);
 
@@ -190,7 +190,7 @@ namespace Mediapipe.Net.Framework.Format
         public byte[] GetChannel(int channelNumber, bool flipVertically)
             => GetChannel(channelNumber, flipVertically, new byte[Width * Height]);
 
-        private delegate MpReturnCode CopyToBufferHandler(IntPtr ptr, IntPtr buffer, int bufferSize);
+        private delegate MpReturnCode CopyToBufferHandler(void* ptr, void* buffer, int bufferSize);
 
         private T[] copyToBuffer<T>(CopyToBufferHandler handler, int bufferSize) where T : unmanaged
         {
@@ -200,7 +200,7 @@ namespace Mediapipe.Net.Framework.Format
             {
                 fixed (T* bufferPtr = buffer)
                 {
-                    handler(MpPtr, (IntPtr)bufferPtr, bufferSize).Assert();
+                    handler(MpPtr, (void*)bufferPtr, bufferSize).Assert();
                 }
             }
 
@@ -225,7 +225,7 @@ namespace Mediapipe.Net.Framework.Format
         /// In the source array, pixels are laid out left to right, top to bottom,
         /// but in the returned array, left to right, top to bottom.
         /// </remarks>
-        private static void readChannel(IntPtr ptr, int channelNumber, int channelCount, int width, int height, int widthStep, bool flipVertically, byte[] colors)
+        private static void readChannel(void* ptr, int channelNumber, int channelCount, int width, int height, int widthStep, bool flipVertically, byte[] colors)
         {
             if (colors.Length != width * height)
                 throw new ArgumentException("colors length is invalid");

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Format
 {
-    public class ImageFrame : MpResourceHandle
+    public unsafe class ImageFrame : MpResourceHandle
     {
         public static readonly uint DefaultAlignmentBoundary = 16;
         public static readonly uint GlDefaultAlignmentBoundary = 4;

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -57,9 +57,9 @@ namespace Mediapipe.Net.Framework.Format
             // Do nothing (pixelData is moved)
         }
 
-        public bool IsEmpty => SafeNativeMethods.mp_ImageFrame__IsEmpty(MpPtr);
+        public bool IsEmpty => SafeNativeMethods.mp_ImageFrame__IsEmpty(MpPtr) > 0;
 
-        public bool IsContiguous => SafeNativeMethods.mp_ImageFrame__IsContiguous(MpPtr);
+        public bool IsContiguous => SafeNativeMethods.mp_ImageFrame__IsContiguous(MpPtr) > 0;
 
         public bool IsAligned(uint alignmentBoundary)
         {

--- a/Mediapipe.Net/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Framework/OutputStreamPoller.cs
@@ -11,7 +11,7 @@ namespace Mediapipe.Net.Framework
 {
     public class OutputStreamPoller<T> : MpResourceHandle
     {
-        public OutputStreamPoller(IntPtr ptr) : base(ptr) { }
+        public OutputStreamPoller(void* ptr) : base(ptr) { }
 
         protected override void DeleteMpPtr()
         {

--- a/Mediapipe.Net/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Framework/OutputStreamPoller.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework
 {
-    public class OutputStreamPoller<T> : MpResourceHandle
+    public unsafe class OutputStreamPoller<T> : MpResourceHandle
     {
         public OutputStreamPoller(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class Anchor3dVectorPacket : Packet<List<Anchor3d>>
     {
         public Anchor3dVectorPacket() : base() { }
-        public Anchor3dVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public Anchor3dVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public Anchor3dVectorPacket(Anchor3d[] value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class Anchor3dVectorPacket : Packet<List<Anchor3d>>
+    public unsafe class Anchor3dVectorPacket : Packet<List<Anchor3d>>
     {
         public Anchor3dVectorPacket() : base() { }
         public Anchor3dVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/Anchor3dVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class Anchor3dVectorPacket : Packet<List<Anchor3d>>
     {
         public Anchor3dVectorPacket() : base() { }
-        public Anchor3dVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public Anchor3dVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public Anchor3dVectorPacket(Anchor3d[] value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/BoolPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/BoolPacket.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class BoolPacket : Packet<bool>
+    public unsafe class BoolPacket : Packet<bool>
     {
         public BoolPacket() : base() { }
 

--- a/Mediapipe.Net/Framework/Packet/BoolPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/BoolPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public BoolPacket() : base() { }
 
-        public BoolPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public BoolPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public BoolPacket(bool value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/BoolPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/BoolPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public BoolPacket() : base() { }
 
-        public BoolPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public BoolPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public BoolPacket(bool value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class ClassificationListPacket : Packet<ClassificationList>
     {
         public ClassificationListPacket() : base() { }
-        public ClassificationListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public ClassificationListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override ClassificationList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class ClassificationListPacket : Packet<ClassificationList>
     {
         public ClassificationListPacket() : base() { }
-        public ClassificationListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public ClassificationListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override ClassificationList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class ClassificationListPacket : Packet<ClassificationList>
+    public unsafe class ClassificationListPacket : Packet<ClassificationList>
     {
         public ClassificationListPacket() : base() { }
         public ClassificationListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class ClassificationListVectorPacket : Packet<List<ClassificationList>>
     {
         public ClassificationListVectorPacket() : base() { }
-        public ClassificationListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public ClassificationListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<ClassificationList> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class ClassificationListVectorPacket : Packet<List<ClassificationList>>
     {
         public ClassificationListVectorPacket() : base() { }
-        public ClassificationListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public ClassificationListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<ClassificationList> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ClassificationListVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class ClassificationListVectorPacket : Packet<List<ClassificationList>>
+    public unsafe class ClassificationListVectorPacket : Packet<List<ClassificationList>>
     {
         public ClassificationListVectorPacket() : base() { }
         public ClassificationListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class DetectionPacket : Packet<Detection>
+    public unsafe class DetectionPacket : Packet<Detection>
     {
         public DetectionPacket() : base() { }
         public DetectionPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class DetectionPacket : Packet<Detection>
     {
         public DetectionPacket() : base() { }
-        public DetectionPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public DetectionPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override Detection Get()
         {

--- a/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class DetectionPacket : Packet<Detection>
     {
         public DetectionPacket() : base() { }
-        public DetectionPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public DetectionPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override Detection Get()
         {

--- a/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class DetectionVectorPacket : Packet<List<Detection>>
+    public unsafe class DetectionVectorPacket : Packet<List<Detection>>
     {
         public DetectionVectorPacket() : base() { }
         public DetectionVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class DetectionVectorPacket : Packet<List<Detection>>
     {
         public DetectionVectorPacket() : base() { }
-        public DetectionVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public DetectionVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<Detection> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/DetectionVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class DetectionVectorPacket : Packet<List<Detection>>
     {
         public DetectionVectorPacket() : base() { }
-        public DetectionVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public DetectionVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<Detection> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
@@ -11,7 +11,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class FaceGeometryPacket : Packet<FaceGeometry.FaceGeometry>
     {
         public FaceGeometryPacket() : base() { }
-        public FaceGeometryPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FaceGeometryPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override FaceGeometry.FaceGeometry Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class FaceGeometryPacket : Packet<FaceGeometry.FaceGeometry>
+    public unsafe class FaceGeometryPacket : Packet<FaceGeometry.FaceGeometry>
     {
         public FaceGeometryPacket() : base() { }
         public FaceGeometryPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryPacket.cs
@@ -11,7 +11,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class FaceGeometryPacket : Packet<FaceGeometry.FaceGeometry>
     {
         public FaceGeometryPacket() : base() { }
-        public FaceGeometryPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FaceGeometryPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override FaceGeometry.FaceGeometry Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class FaceGeometryVectorPacket : Packet<List<FaceGeometry.FaceGeometry>>
     {
         public FaceGeometryVectorPacket() : base() { }
-        public FaceGeometryVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FaceGeometryVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<FaceGeometry.FaceGeometry> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class FaceGeometryVectorPacket : Packet<List<FaceGeometry.FaceGeometry>>
+    public unsafe class FaceGeometryVectorPacket : Packet<List<FaceGeometry.FaceGeometry>>
     {
         public FaceGeometryVectorPacket() : base() { }
         public FaceGeometryVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FaceGeometryVectorPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class FaceGeometryVectorPacket : Packet<List<FaceGeometry.FaceGeometry>>
     {
         public FaceGeometryVectorPacket() : base() { }
-        public FaceGeometryVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FaceGeometryVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<FaceGeometry.FaceGeometry> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Framework.Packet
 
         public FloatArrayPacket() : base() { }
 
-        public FloatArrayPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FloatArrayPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public FloatArrayPacket(float[] value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -5,6 +5,7 @@
 using System;
 using Mediapipe.Net.Framework.Port;
 using Mediapipe.Net.Native;
+using Mediapipe.Net.Util;
 
 namespace Mediapipe.Net.Framework.Packet
 {
@@ -48,13 +49,7 @@ namespace Mediapipe.Net.Framework.Packet
             if (Length < 0)
                 throw new InvalidOperationException("The array's length is unknown, set Length first");
 
-            var result = new float[Length];
-
-            var src = GetArrayPtr();
-            for (int i = 0; i < result.Length; i++)
-                result[i] = src[i];
-
-            return result;
+            return UnsafeUtil.SafeArrayCopy(GetArrayPtr(), Length);
         }
 
         public float* GetArrayPtr()

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -50,15 +50,9 @@ namespace Mediapipe.Net.Framework.Packet
 
             var result = new float[Length];
 
-            unsafe
-            {
-                var src = (float*)GetArrayPtr();
-
-                for (var i = 0; i < result.Length; i++)
-                {
-                    result[i] = *src++;
-                }
-            }
+            var src = (float*)GetArrayPtr();
+            for (int i = 0; i < result.Length; i++)
+                result[i] = src[i];
 
             return result;
         }

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class FloatArrayPacket : Packet<float[]>
+    public unsafe class FloatArrayPacket : Packet<float[]>
     {
         private int length = -1;
 

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -50,18 +50,18 @@ namespace Mediapipe.Net.Framework.Packet
 
             var result = new float[Length];
 
-            var src = (float*)GetArrayPtr();
+            var src = GetArrayPtr();
             for (int i = 0; i < result.Length; i++)
                 result[i] = src[i];
 
             return result;
         }
 
-        public void* GetArrayPtr()
+        public float* GetArrayPtr()
         {
-            UnsafeNativeMethods.mp_Packet__GetFloatArray(MpPtr, out var value).Assert();
+            UnsafeNativeMethods.mp_Packet__GetFloatArray(MpPtr, out float* array).Assert();
             GC.KeepAlive(this);
-            return value;
+            return array;
         }
 
         public override StatusOr<float[]> Consume() => throw new NotSupportedException();

--- a/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatArrayPacket.cs
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Framework.Packet
 
         public FloatArrayPacket() : base() { }
 
-        public FloatArrayPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FloatArrayPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public FloatArrayPacket(float[] value) : base()
         {
@@ -63,7 +63,7 @@ namespace Mediapipe.Net.Framework.Packet
             return result;
         }
 
-        public IntPtr GetArrayPtr()
+        public void* GetArrayPtr()
         {
             UnsafeNativeMethods.mp_Packet__GetFloatArray(MpPtr, out var value).Assert();
             GC.KeepAlive(this);

--- a/Mediapipe.Net/Framework/Packet/FloatPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public FloatPacket() : base() { }
 
-        public FloatPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FloatPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public FloatPacket(float value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/FloatPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public FloatPacket() : base() { }
 
-        public FloatPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FloatPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public FloatPacket(float value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/FloatPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FloatPacket.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class FloatPacket : Packet<float>
+    public unsafe class FloatPacket : Packet<float>
     {
         public FloatPacket() : base() { }
 

--- a/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe
     public class FrameAnnotationPacket : Packet<FrameAnnotation>
     {
         public FrameAnnotationPacket() : base() { }
-        public FrameAnnotationPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FrameAnnotationPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override FrameAnnotation Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe
     public unsafe class FrameAnnotationPacket : Packet<FrameAnnotation>
     {
         public FrameAnnotationPacket() : base() { }
-        public FrameAnnotationPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public FrameAnnotationPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override FrameAnnotation Get()
         {

--- a/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/FrameAnnotationPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe
 {
-    public class FrameAnnotationPacket : Packet<FrameAnnotation>
+    public unsafe class FrameAnnotationPacket : Packet<FrameAnnotation>
     {
         public FrameAnnotationPacket() : base() { }
         public FrameAnnotationPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class GpuBufferPacket : Packet<GpuBuffer>
     {
         public GpuBufferPacket() : base() { }
-        public GpuBufferPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public GpuBufferPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public GpuBufferPacket(GpuBuffer gpuBuffer) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class GpuBufferPacket : Packet<GpuBuffer>
     {
         public GpuBufferPacket() : base() { }
-        public GpuBufferPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public GpuBufferPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public GpuBufferPacket(GpuBuffer gpuBuffer) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/GpuBufferPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class GpuBufferPacket : Packet<GpuBuffer>
+    public unsafe class GpuBufferPacket : Packet<GpuBuffer>
     {
         public GpuBufferPacket() : base() { }
         public GpuBufferPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public ImageFramePacket() : base() { }
 
-        public ImageFramePacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public ImageFramePacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public ImageFramePacket(ImageFrame imageFrame) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class ImageFramePacket : Packet<ImageFrame>
+    public unsafe class ImageFramePacket : Packet<ImageFrame>
     {
         public ImageFramePacket() : base() { }
 

--- a/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/ImageFramePacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public ImageFramePacket() : base() { }
 
-        public ImageFramePacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public ImageFramePacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public ImageFramePacket(ImageFrame imageFrame) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/IntPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/IntPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public IntPacket() : base() { }
 
-        public IntPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public IntPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public IntPacket(int value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/IntPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/IntPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public IntPacket() : base() { }
 
-        public IntPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public IntPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public IntPacket(int value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/IntPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/IntPacket.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class IntPacket : Packet<int>
+    public unsafe class IntPacket : Packet<int>
     {
         public IntPacket() : base() { }
 

--- a/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class LandmarkListPacket : Packet<LandmarkList>
+    public unsafe class LandmarkListPacket : Packet<LandmarkList>
     {
         public LandmarkListPacket() : base() { }
         public LandmarkListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class LandmarkListPacket : Packet<LandmarkList>
     {
         public LandmarkListPacket() : base() { }
-        public LandmarkListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public LandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override LandmarkList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class LandmarkListPacket : Packet<LandmarkList>
     {
         public LandmarkListPacket() : base() { }
-        public LandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public LandmarkListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override LandmarkList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class LandmarkListVectorPacket : Packet<List<LandmarkList>>
     {
         public LandmarkListVectorPacket() : base() { }
-        public LandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public LandmarkListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<LandmarkList> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class LandmarkListVectorPacket : Packet<List<LandmarkList>>
     {
         public LandmarkListVectorPacket() : base() { }
-        public LandmarkListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public LandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<LandmarkList> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/LandmarkListVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class LandmarkListVectorPacket : Packet<List<LandmarkList>>
+    public unsafe class LandmarkListVectorPacket : Packet<List<LandmarkList>>
     {
         public LandmarkListVectorPacket() : base() { }
         public LandmarkListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class NormalizedLandmarkListPacket : Packet<NormalizedLandmarkList>
     {
         public NormalizedLandmarkListPacket() : base() { }
-        public NormalizedLandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedLandmarkListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override NormalizedLandmarkList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class NormalizedLandmarkListPacket : Packet<NormalizedLandmarkList>
     {
         public NormalizedLandmarkListPacket() : base() { }
-        public NormalizedLandmarkListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedLandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override NormalizedLandmarkList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class NormalizedLandmarkListPacket : Packet<NormalizedLandmarkList>
+    public unsafe class NormalizedLandmarkListPacket : Packet<NormalizedLandmarkList>
     {
         public NormalizedLandmarkListPacket() : base() { }
         public NormalizedLandmarkListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class NormalizedLandmarkListVectorPacket : Packet<List<NormalizedLandmarkList>>
     {
         public NormalizedLandmarkListVectorPacket() : base() { }
-        public NormalizedLandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedLandmarkListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<NormalizedLandmarkList> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class NormalizedLandmarkListVectorPacket : Packet<List<NormalizedLandmarkList>>
+    public unsafe class NormalizedLandmarkListVectorPacket : Packet<List<NormalizedLandmarkList>>
     {
         public NormalizedLandmarkListVectorPacket() : base() { }
         public NormalizedLandmarkListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class NormalizedLandmarkListVectorPacket : Packet<List<NormalizedLandmarkList>>
     {
         public NormalizedLandmarkListVectorPacket() : base() { }
-        public NormalizedLandmarkListVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedLandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<NormalizedLandmarkList> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class NormalizedRectPacket : Packet<NormalizedRect>
     {
         public NormalizedRectPacket() : base() { }
-        public NormalizedRectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedRectPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override NormalizedRect Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class NormalizedRectPacket : Packet<NormalizedRect>
+    public unsafe class NormalizedRectPacket : Packet<NormalizedRect>
     {
         public NormalizedRectPacket() : base() { }
         public NormalizedRectPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class NormalizedRectPacket : Packet<NormalizedRect>
     {
         public NormalizedRectPacket() : base() { }
-        public NormalizedRectPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedRectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override NormalizedRect Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class NormalizedRectVectorPacket : Packet<List<NormalizedRect>>
     {
         public NormalizedRectVectorPacket() : base() { }
-        public NormalizedRectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedRectVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<NormalizedRect> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class NormalizedRectVectorPacket : Packet<List<NormalizedRect>>
     {
         public NormalizedRectVectorPacket() : base() { }
-        public NormalizedRectVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public NormalizedRectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<NormalizedRect> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/NormalizedRectVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class NormalizedRectVectorPacket : Packet<List<NormalizedRect>>
+    public unsafe class NormalizedRectVectorPacket : Packet<List<NormalizedRect>>
     {
         public NormalizedRectVectorPacket() : base() { }
         public NormalizedRectVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -22,7 +22,7 @@ namespace Mediapipe.Net.Framework.Packet
         // Temp backwards compatibility until we find something better than the Activator. ¬¬
         public Packet(IntPtr ptr, bool isOwner = true) : base((void*)ptr, isOwner) { }
 
-        /// <exception cref="MediaPipeException">Thrown when the value is not set</exception>
+        /// <exception cref="MediapipeException">Thrown when the value is not set</exception>
         public abstract T Get();
 
         public abstract StatusOr<T> Consume();

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -17,7 +17,7 @@ namespace Mediapipe.Net.Framework.Packet
             Ptr = ptr;
         }
 
-        public Packet(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public Packet(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         /// <exception cref="MediaPipeException">Thrown when the value is not set</exception>
         public abstract T Get();

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public abstract class Packet<T> : MpResourceHandle
+    public unsafe abstract class Packet<T> : MpResourceHandle
     {
         public Packet() : base()
         {

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -19,6 +19,9 @@ namespace Mediapipe.Net.Framework.Packet
 
         public Packet(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
+        // Temp backwards compatibility until we find something better than the Activator. ¬¬
+        public Packet(IntPtr ptr, bool isOwner = true) : base((void*)ptr, isOwner) { }
+
         /// <exception cref="MediaPipeException">Thrown when the value is not set</exception>
         public abstract T Get();
 
@@ -29,7 +32,6 @@ namespace Mediapipe.Net.Framework.Packet
         public Packet<T>? At(Timestamp timestamp)
         {
             UnsafeNativeMethods.mp_Packet__At__Rt(MpPtr, timestamp.MpPtr, out var packetPtr).Assert();
-
             GC.KeepAlive(timestamp);
 
             // Oh gosh... the Activator...

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -36,7 +36,7 @@ namespace Mediapipe.Net.Framework.Packet
             return (Packet<T>?)Activator.CreateInstance(GetType(), (IntPtr)packetPtr, true);
         }
 
-        public bool IsEmpty() => SafeNativeMethods.mp_Packet__IsEmpty(MpPtr);
+        public bool IsEmpty() => SafeNativeMethods.mp_Packet__IsEmpty(MpPtr) > 0;
 
         public Status ValidateAsProtoMessageLite()
         {

--- a/Mediapipe.Net/Framework/Packet/Packet.cs
+++ b/Mediapipe.Net/Framework/Packet/Packet.cs
@@ -33,7 +33,7 @@ namespace Mediapipe.Net.Framework.Packet
             GC.KeepAlive(timestamp);
 
             // Oh gosh... the Activator...
-            return (Packet<T>?)Activator.CreateInstance(GetType(), packetPtr, true);
+            return (Packet<T>?)Activator.CreateInstance(GetType(), (IntPtr)packetPtr, true);
         }
 
         public bool IsEmpty() => SafeNativeMethods.mp_Packet__IsEmpty(MpPtr);

--- a/Mediapipe.Net/Framework/Packet/RectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class RectPacket : Packet<Rect>
     {
         public RectPacket() : base() { }
-        public RectPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public RectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override Rect Get()
         {

--- a/Mediapipe.Net/Framework/Packet/RectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class RectPacket : Packet<Rect>
+    public unsafe class RectPacket : Packet<Rect>
     {
         public RectPacket() : base() { }
         public RectPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/RectPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class RectPacket : Packet<Rect>
     {
         public RectPacket() : base() { }
-        public RectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public RectPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override Rect Get()
         {

--- a/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class RectVectorPacket : Packet<List<Rect>>
     {
         public RectVectorPacket() : base() { }
-        public RectVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public RectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<Rect> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class RectVectorPacket : Packet<List<Rect>>
     {
         public RectVectorPacket() : base() { }
-        public RectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public RectVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override List<Rect> Get()
         {

--- a/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/RectVectorPacket.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class RectVectorPacket : Packet<List<Rect>>
+    public unsafe class RectVectorPacket : Packet<List<Rect>>
     {
         public RectVectorPacket() : base() { }
         public RectVectorPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/SidePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/SidePacket.cs
@@ -32,7 +32,7 @@ namespace Mediapipe.Net.Framework.Packet
             GC.KeepAlive(this);
 
             // Oh gosh²... the Activator²...
-            return (T?)Activator.CreateInstance(typeof(T), packetPtr, true);
+            return (T?)Activator.CreateInstance(typeof(T), (IntPtr)packetPtr, true);
         }
 
         public void Emplace<T>(string key, Packet<T> packet)

--- a/Mediapipe.Net/Framework/Packet/SidePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/SidePacket.cs
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Framework.Packet
         {
             UnsafeNativeMethods.mp_SidePacket__at__PKc(MpPtr, key, out var packetPtr).Assert();
 
-            if (packetPtr == void*.Zero)
+            if (packetPtr == null)
                 return default; // null
 
             GC.KeepAlive(this);

--- a/Mediapipe.Net/Framework/Packet/SidePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/SidePacket.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class SidePacket : MpResourceHandle
+    public unsafe class SidePacket : MpResourceHandle
     {
         public SidePacket() : base()
         {

--- a/Mediapipe.Net/Framework/Packet/SidePacket.cs
+++ b/Mediapipe.Net/Framework/Packet/SidePacket.cs
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Framework.Packet
         {
             UnsafeNativeMethods.mp_SidePacket__at__PKc(MpPtr, key, out var packetPtr).Assert();
 
-            if (packetPtr == IntPtr.Zero)
+            if (packetPtr == void*.Zero)
                 return default; // null
 
             GC.KeepAlive(this);

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -50,7 +50,7 @@ namespace Mediapipe.Net.Framework.Packet
             GC.KeepAlive(this);
 
             var bytes = new byte[size];
-            Marshal.Copy(strPtr, bytes, 0, size);
+            Marshal.Copy((IntPtr)strPtr, bytes, 0, size);
             UnsafeNativeMethods.delete_array__PKc(strPtr);
 
             return bytes;

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -46,11 +46,13 @@ namespace Mediapipe.Net.Framework.Packet
 
         public byte[] GetByteArray()
         {
-            UnsafeNativeMethods.mp_Packet__GetByteString(MpPtr, out var strPtr, out var size).Assert();
+            UnsafeNativeMethods.mp_Packet__GetByteString(MpPtr, out var ptr, out var size).Assert();
             GC.KeepAlive(this);
 
+            var strPtr = (sbyte*)ptr;
             var bytes = new byte[size];
-            Marshal.Copy((IntPtr)strPtr, bytes, 0, size);
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = (byte)strPtr[i];
             UnsafeNativeMethods.delete_array__PKc(strPtr);
 
             return bytes;

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public StringPacket() : base() { }
 
-        public StringPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public StringPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public StringPacket(string value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -45,10 +45,9 @@ namespace Mediapipe.Net.Framework.Packet
 
         public byte[] GetByteArray()
         {
-            UnsafeNativeMethods.mp_Packet__GetByteString(MpPtr, out var ptr, out var size).Assert();
+            UnsafeNativeMethods.mp_Packet__GetByteString(MpPtr, out var strPtr, out var size).Assert();
             GC.KeepAlive(this);
 
-            var strPtr = (sbyte*)ptr;
             var bytes = new byte[size];
             for (int i = 0; i < bytes.Length; i++)
                 bytes[i] = (byte)strPtr[i];

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -5,6 +5,7 @@
 using System;
 using Mediapipe.Net.Framework.Port;
 using Mediapipe.Net.Native;
+using Mediapipe.Net.Util;
 
 namespace Mediapipe.Net.Framework.Packet
 {
@@ -48,9 +49,7 @@ namespace Mediapipe.Net.Framework.Packet
             UnsafeNativeMethods.mp_Packet__GetByteString(MpPtr, out var strPtr, out var size).Assert();
             GC.KeepAlive(this);
 
-            var bytes = new byte[size];
-            for (int i = 0; i < bytes.Length; i++)
-                bytes[i] = (byte)strPtr[i];
+            byte[] bytes = UnsafeUtil.SafeArrayCopy((byte*)strPtr, size);
             UnsafeNativeMethods.delete_array__PKc(strPtr);
 
             return bytes;

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class StringPacket : Packet<string>
+    public unsafe class StringPacket : Packet<string>
     {
         public StringPacket() : base() { }
 

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -3,7 +3,6 @@
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
 using System;
-using System.Runtime.InteropServices;
 using Mediapipe.Net.Framework.Port;
 using Mediapipe.Net.Native;
 

--- a/Mediapipe.Net/Framework/Packet/StringPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/StringPacket.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Framework.Packet
     {
         public StringPacket() : base() { }
 
-        public StringPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public StringPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public StringPacket(string value) : base()
         {

--- a/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public unsafe class TimedModelMatrixProtoListPacket : Packet<TimedModelMatrixProtoList>
     {
         public TimedModelMatrixProtoListPacket() : base() { }
-        public TimedModelMatrixProtoListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public TimedModelMatrixProtoListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override TimedModelMatrixProtoList Get()
         {

--- a/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Packet
 {
-    public class TimedModelMatrixProtoListPacket : Packet<TimedModelMatrixProtoList>
+    public unsafe class TimedModelMatrixProtoListPacket : Packet<TimedModelMatrixProtoList>
     {
         public TimedModelMatrixProtoListPacket() : base() { }
         public TimedModelMatrixProtoListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
+++ b/Mediapipe.Net/Framework/Packet/TimedModelMatrixProtoListPacket.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Framework.Packet
     public class TimedModelMatrixProtoListPacket : Packet<TimedModelMatrixProtoList>
     {
         public TimedModelMatrixProtoListPacket() : base() { }
-        public TimedModelMatrixProtoListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public TimedModelMatrixProtoListPacket(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         public override TimedModelMatrixProtoList Get()
         {

--- a/Mediapipe.Net/Framework/Port/Status.cs
+++ b/Mediapipe.Net/Framework/Port/Status.cs
@@ -47,7 +47,7 @@ namespace Mediapipe.Net.Framework.Port
         {
             if (ok is bool valueOfOk)
                 return valueOfOk;
-            ok = SafeNativeMethods.absl_Status__ok(MpPtr);
+            ok = SafeNativeMethods.absl_Status__ok(MpPtr) > 0;
             return (bool)ok;
         }
 

--- a/Mediapipe.Net/Framework/Port/Status.cs
+++ b/Mediapipe.Net/Framework/Port/Status.cs
@@ -31,7 +31,7 @@ namespace Mediapipe.Net.Framework.Port
             Unauthenticated = 16,
         }
 
-        public Status(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public Status(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.absl_Status__delete(Ptr);
 

--- a/Mediapipe.Net/Framework/Port/Status.cs
+++ b/Mediapipe.Net/Framework/Port/Status.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Native;
 

--- a/Mediapipe.Net/Framework/Port/Status.cs
+++ b/Mediapipe.Net/Framework/Port/Status.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Port
 {
-    public class Status : MpResourceHandle
+    public unsafe class Status : MpResourceHandle
     {
         public enum StatusCode : int
         {

--- a/Mediapipe.Net/Framework/Port/StatusOr.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOr.cs
@@ -7,7 +7,7 @@ using Mediapipe.Net.Core;
 
 namespace Mediapipe.Net.Framework.Port
 {
-    public abstract class StatusOr<T> : MpResourceHandle
+    public unsafe abstract class StatusOr<T> : MpResourceHandle
     {
         public StatusOr(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Port/StatusOr.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOr.cs
@@ -9,7 +9,7 @@ namespace Mediapipe.Net.Framework.Port
 {
     public abstract class StatusOr<T> : MpResourceHandle
     {
-        public StatusOr(IntPtr ptr) : base(ptr) { }
+        public StatusOr(void* ptr) : base(ptr) { }
 
         public abstract Status Status { get; }
         public virtual bool Ok() => Status.Ok();

--- a/Mediapipe.Net/Framework/Port/StatusOr.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOr.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using Mediapipe.Net.Core;
 
 namespace Mediapipe.Net.Framework.Port

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
@@ -30,7 +30,7 @@ namespace Mediapipe.Net.Framework.Port
             }
         }
 
-        public override bool Ok() => SafeNativeMethods.mp_StatusOrGpuBuffer__ok(MpPtr);
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrGpuBuffer__ok(MpPtr) > 0;
 
         public override GpuBuffer Value()
         {

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Framework.Port
 {
     public class StatusOrGpuBuffer : StatusOr<GpuBuffer>
     {
-        public StatusOrGpuBuffer(IntPtr ptr) : base(ptr) { }
+        public StatusOrGpuBuffer(void* ptr) : base(ptr) { }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_StatusOrGpuBuffer__delete(Ptr);
 

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuBuffer.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Port
 {
-    public class StatusOrGpuBuffer : StatusOr<GpuBuffer>
+    public unsafe class StatusOrGpuBuffer : StatusOr<GpuBuffer>
     {
         public StatusOrGpuBuffer(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Framework.Port
 {
     public class StatusOrGpuResources : StatusOr<GpuResources>
     {
-        public StatusOrGpuResources(IntPtr ptr) : base(ptr) { }
+        public StatusOrGpuResources(void* ptr) : base(ptr) { }
 
         protected override void DeleteMpPtr()
         {

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Port
 {
-    public class StatusOrGpuResources : StatusOr<GpuResources>
+    public unsafe class StatusOrGpuResources : StatusOr<GpuResources>
     {
         public StatusOrGpuResources(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrGpuResources.cs
@@ -33,7 +33,7 @@ namespace Mediapipe.Net.Framework.Port
             }
         }
 
-        public override bool Ok() => SafeNativeMethods.mp_StatusOrGpuResources__ok(MpPtr);
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrGpuResources__ok(MpPtr) > 0;
 
         public override GpuResources Value()
         {

--- a/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
@@ -33,7 +33,7 @@ namespace Mediapipe.Net.Framework.Port
             }
         }
 
-        public override bool Ok() => SafeNativeMethods.mp_StatusOrImageFrame__ok(MpPtr);
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrImageFrame__ok(MpPtr) > 0;
 
         public override ImageFrame Value()
         {

--- a/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Port
 {
-    public class StatusOrImageFrame : StatusOr<ImageFrame>
+    public unsafe class StatusOrImageFrame : StatusOr<ImageFrame>
     {
         public StatusOrImageFrame(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrImageFrame.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Framework.Port
 {
     public class StatusOrImageFrame : StatusOr<ImageFrame>
     {
-        public StatusOrImageFrame(IntPtr ptr) : base(ptr) { }
+        public StatusOrImageFrame(void* ptr) : base(ptr) { }
 
         protected override void DeleteMpPtr()
         {

--- a/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
@@ -9,7 +9,7 @@ namespace Mediapipe.Net.Framework.Port
 {
     public class StatusOrPoller<T> : StatusOr<OutputStreamPoller<T>>
     {
-        public StatusOrPoller(IntPtr ptr) : base(ptr) { }
+        public StatusOrPoller(void* ptr) : base(ptr) { }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_StatusOrPoller__delete(Ptr);
 

--- a/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
@@ -29,7 +29,7 @@ namespace Mediapipe.Net.Framework.Port
             }
         }
 
-        public override bool Ok() => SafeNativeMethods.mp_StatusOrPoller__ok(MpPtr);
+        public override bool Ok() => SafeNativeMethods.mp_StatusOrPoller__ok(MpPtr) > 0;
 
         public override OutputStreamPoller<T> Value()
         {

--- a/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
+++ b/Mediapipe.Net/Framework/Port/StatusOrPoller.cs
@@ -7,7 +7,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework.Port
 {
-    public class StatusOrPoller<T> : StatusOr<OutputStreamPoller<T>>
+    public unsafe class StatusOrPoller<T> : StatusOr<OutputStreamPoller<T>>
     {
         public StatusOrPoller(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Framework/Timestamp.cs
@@ -45,11 +45,11 @@ namespace Mediapipe.Net.Framework
 
         public long Microseconds => SafeNativeMethods.mp_Timestamp__Microseconds(MpPtr);
 
-        public bool IsSpecialValue => SafeNativeMethods.mp_Timestamp__IsSpecialValue(MpPtr);
+        public bool IsSpecialValue => SafeNativeMethods.mp_Timestamp__IsSpecialValue(MpPtr) > 0;
 
-        public bool IsRangeValue => SafeNativeMethods.mp_Timestamp__IsRangeValue(MpPtr);
+        public bool IsRangeValue => SafeNativeMethods.mp_Timestamp__IsRangeValue(MpPtr) > 0;
 
-        public bool IsAllowedInStream => SafeNativeMethods.mp_Timestamp__IsAllowedInStream(MpPtr);
+        public bool IsAllowedInStream => SafeNativeMethods.mp_Timestamp__IsAllowedInStream(MpPtr) > 0;
 
         public string? DebugString => MarshalStringFromNative(UnsafeNativeMethods.mp_Timestamp__DebugString);
 

--- a/Mediapipe.Net/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Framework/Timestamp.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Framework
 {
-    public class Timestamp : MpResourceHandle, IEquatable<Timestamp>
+    public unsafe class Timestamp : MpResourceHandle, IEquatable<Timestamp>
     {
         public Timestamp(void* ptr) : base(ptr) { }
 

--- a/Mediapipe.Net/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Framework/Timestamp.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Framework
 {
     public class Timestamp : MpResourceHandle, IEquatable<Timestamp>
     {
-        public Timestamp(IntPtr ptr) : base(ptr) { }
+        public Timestamp(void* ptr) : base(ptr) { }
 
         public Timestamp(long value) : base()
         {

--- a/Mediapipe.Net/Gpu/Egl.cs
+++ b/Mediapipe.Net/Gpu/Egl.cs
@@ -11,6 +11,6 @@ namespace Mediapipe.Net.Gpu
     [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
     public class Egl
     {
-        public static IntPtr GetCurrentContext() => SafeNativeMethods.eglGetCurrentContext();
+        public static void* GetCurrentContext() => SafeNativeMethods.eglGetCurrentContext();
     }
 }

--- a/Mediapipe.Net/Gpu/Egl.cs
+++ b/Mediapipe.Net/Gpu/Egl.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 namespace Mediapipe.Net.Gpu
 {
     [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
-    public class Egl
+    public unsafe class Egl
     {
         public static void* GetCurrentContext() => SafeNativeMethods.eglGetCurrentContext();
     }

--- a/Mediapipe.Net/Gpu/Egl.cs
+++ b/Mediapipe.Net/Gpu/Egl.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.Versioning;
 using Mediapipe.Net.Native;
 

--- a/Mediapipe.Net/Gpu/Gl.cs
+++ b/Mediapipe.Net/Gpu/Gl.cs
@@ -13,7 +13,7 @@ namespace Mediapipe.Net.Gpu
 
         public static void Flush() => UnsafeNativeMethods.glFlush();
 
-        public static void ReadPixels(int x, int y, int width, int height, uint glFormat, uint glType, IntPtr pixels)
+        public static void ReadPixels(int x, int y, int width, int height, uint glFormat, uint glType, void* pixels)
             => UnsafeNativeMethods.glReadPixels(x, y, width, height, glFormat, glType, pixels);
     }
 }

--- a/Mediapipe.Net/Gpu/Gl.cs
+++ b/Mediapipe.Net/Gpu/Gl.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
@@ -13,7 +12,7 @@ namespace Mediapipe.Net.Gpu
 
         public static void Flush() => UnsafeNativeMethods.glFlush();
 
-        public static void ReadPixels(int x, int y, int width, int height, uint glFormat, uint glType, void* pixels)
+        public unsafe static void ReadPixels(int x, int y, int width, int height, uint glFormat, uint glType, void* pixels)
             => UnsafeNativeMethods.glReadPixels(x, y, width, height, glFormat, glType, pixels);
     }
 }

--- a/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
@@ -14,7 +14,7 @@ namespace Mediapipe.Net.Gpu
 {
     public class GlCalculatorHelper : MpResourceHandle
     {
-        public delegate IntPtr NativeGlStatusFunction();
+        public delegate void* NativeGlStatusFunction();
         public delegate Status GlStatusFunction();
 
         public GlCalculatorHelper() : base()

--- a/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
@@ -138,6 +138,6 @@ namespace Mediapipe.Net.Gpu
             return new GlContext(glContextPtr, false);
         }
 
-        public bool Initialized() => SafeNativeMethods.mp_GlCalculatorHelper__Initialized(MpPtr);
+        public bool Initialized() => SafeNativeMethods.mp_GlCalculatorHelper__Initialized(MpPtr) > 0;
     }
 }

--- a/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Gpu/GlCalculatorHelper.cs
@@ -12,7 +12,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GlCalculatorHelper : MpResourceHandle
+    public unsafe class GlCalculatorHelper : MpResourceHandle
     {
         public delegate void* NativeGlStatusFunction();
         public delegate Status GlStatusFunction();

--- a/Mediapipe.Net/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Gpu/GlContext.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.Versioning;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Native;

--- a/Mediapipe.Net/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Gpu/GlContext.cs
@@ -57,7 +57,7 @@ namespace Mediapipe.Net.Gpu
         [SupportedOSPlatform("IOS")]
         public void* EaglContext => SafeNativeMethods.mp_GlContext__eagl_context(MpPtr);
 
-        public bool IsCurrent() => SafeNativeMethods.mp_GlContext__IsCurrent(MpPtr);
+        public bool IsCurrent() => SafeNativeMethods.mp_GlContext__IsCurrent(MpPtr) > 0;
 
         public int GlMajorVersion => SafeNativeMethods.mp_GlContext__gl_major_version(MpPtr);
 

--- a/Mediapipe.Net/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Gpu/GlContext.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GlContext : MpResourceHandle
+    public unsafe class GlContext : MpResourceHandle
     {
         private SharedPtrHandle? sharedPtrHandle;
 

--- a/Mediapipe.Net/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Gpu/GlContext.cs
@@ -16,10 +16,10 @@ namespace Mediapipe.Net.Gpu
         public static GlContext? GetCurrent()
         {
             UnsafeNativeMethods.mp_GlContext_GetCurrent(out var glContextPtr).Assert();
-            return glContextPtr == IntPtr.Zero ? null : new GlContext(glContextPtr);
+            return glContextPtr == void*.Zero ? null : new GlContext(glContextPtr);
         }
 
-        public GlContext(IntPtr ptr, bool isOwner = true) : base(isOwner)
+        public GlContext(void* ptr, bool isOwner = true) : base(isOwner)
         {
             sharedPtrHandle = new SharedGlContextPtr(ptr, isOwner);
             Ptr = sharedPtrHandle.Get();
@@ -40,23 +40,23 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public IntPtr SharedPtr => sharedPtrHandle == null ? IntPtr.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
-        public IntPtr EglDisplay => SafeNativeMethods.mp_GlContext__egl_display(MpPtr);
+        public void* EglDisplay => SafeNativeMethods.mp_GlContext__egl_display(MpPtr);
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
-        public IntPtr EglConfig => SafeNativeMethods.mp_GlContext__egl_config(MpPtr);
+        public void* EglConfig => SafeNativeMethods.mp_GlContext__egl_config(MpPtr);
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
-        public IntPtr EglContext => SafeNativeMethods.mp_GlContext__egl_context(MpPtr);
+        public void* EglContext => SafeNativeMethods.mp_GlContext__egl_context(MpPtr);
 
         // NOTE: (from homuler) On macOS, native libs cannot be built with GPU enabled, so it cannot be used actually.
         [SupportedOSPlatform("OSX")]
-        public IntPtr NsglContext => SafeNativeMethods.mp_GlContext__nsgl_context(MpPtr);
+        public void* NsglContext => SafeNativeMethods.mp_GlContext__nsgl_context(MpPtr);
 
         [SupportedOSPlatform("IOS")]
-        public IntPtr EaglContext => SafeNativeMethods.mp_GlContext__eagl_context(MpPtr);
+        public void* EaglContext => SafeNativeMethods.mp_GlContext__eagl_context(MpPtr);
 
         public bool IsCurrent() => SafeNativeMethods.mp_GlContext__IsCurrent(MpPtr);
 
@@ -69,11 +69,11 @@ namespace Mediapipe.Net.Gpu
         // TODO: Put it in its own file
         private class SharedGlContextPtr : SharedPtrHandle
         {
-            public SharedGlContextPtr(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+            public SharedGlContextPtr(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
             protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_SharedGlContext__delete(Ptr);
 
-            public override IntPtr Get() => SafeNativeMethods.mp_SharedGlContext__get(MpPtr);
+            public override void* Get() => SafeNativeMethods.mp_SharedGlContext__get(MpPtr);
 
             public override void Reset() => UnsafeNativeMethods.mp_SharedGlContext__reset(MpPtr);
         }

--- a/Mediapipe.Net/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Gpu/GlContext.cs
@@ -16,7 +16,7 @@ namespace Mediapipe.Net.Gpu
         public static GlContext? GetCurrent()
         {
             UnsafeNativeMethods.mp_GlContext_GetCurrent(out var glContextPtr).Assert();
-            return glContextPtr == void*.Zero ? null : new GlContext(glContextPtr);
+            return glContextPtr == null ? null : new GlContext(glContextPtr);
         }
 
         public GlContext(void* ptr, bool isOwner = true) : base(isOwner)
@@ -40,7 +40,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? null : sharedPtrHandle.MpPtr;
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         public void* EglDisplay => SafeNativeMethods.mp_GlContext__egl_display(MpPtr);

--- a/Mediapipe.Net/Gpu/GlSyncPoint.cs
+++ b/Mediapipe.Net/Gpu/GlSyncPoint.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Gpu
     {
         private SharedPtrHandle? sharedPtrHandle;
 
-        public GlSyncPoint(IntPtr ptr) : base(ptr)
+        public GlSyncPoint(void* ptr) : base(ptr)
         {
             sharedPtrHandle = new SharedGlSyncPointPtr(ptr);
             Ptr = sharedPtrHandle.Get();
@@ -33,7 +33,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public IntPtr SharedPtr => sharedPtrHandle == null ? IntPtr.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
 
         public void Wait() => UnsafeNativeMethods.mp_GlSyncPoint__Wait(MpPtr).Assert();
 
@@ -60,11 +60,11 @@ namespace Mediapipe.Net.Gpu
         // TODO: Put it in its own file
         private class SharedGlSyncPointPtr : SharedPtrHandle
         {
-            public SharedGlSyncPointPtr(IntPtr ptr) : base(ptr) { }
+            public SharedGlSyncPointPtr(void* ptr) : base(ptr) { }
 
             protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_GlSyncToken__delete(Ptr);
 
-            public override IntPtr Get() => SafeNativeMethods.mp_GlSyncToken__get(MpPtr);
+            public override void* Get() => SafeNativeMethods.mp_GlSyncToken__get(MpPtr);
 
             public override void Reset() => UnsafeNativeMethods.mp_GlSyncToken__reset(MpPtr);
         }

--- a/Mediapipe.Net/Gpu/GlSyncPoint.cs
+++ b/Mediapipe.Net/Gpu/GlSyncPoint.cs
@@ -33,7 +33,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? null : sharedPtrHandle.MpPtr;
 
         public void Wait() => UnsafeNativeMethods.mp_GlSyncPoint__Wait(MpPtr).Assert();
 

--- a/Mediapipe.Net/Gpu/GlSyncPoint.cs
+++ b/Mediapipe.Net/Gpu/GlSyncPoint.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GlSyncPoint : MpResourceHandle
+    public unsafe class GlSyncPoint : MpResourceHandle
     {
         private SharedPtrHandle? sharedPtrHandle;
 

--- a/Mediapipe.Net/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Gpu/GlTexture.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GlTexture : MpResourceHandle
+    public unsafe class GlTexture : MpResourceHandle
     {
         public GlTexture() : base()
         {

--- a/Mediapipe.Net/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Gpu/GlTexture.cs
@@ -16,7 +16,7 @@ namespace Mediapipe.Net.Gpu
             Ptr = ptr;
         }
 
-        public GlTexture(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public GlTexture(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_GlTexture__delete(Ptr);
 

--- a/Mediapipe.Net/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Gpu/GlTextureBuffer.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GlTextureBuffer : MpResourceHandle
+    public unsafe class GlTextureBuffer : MpResourceHandle
     {
         private SharedPtrHandle? sharedPtrHandle;
 

--- a/Mediapipe.Net/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Gpu/GlTextureBuffer.cs
@@ -17,9 +17,9 @@ namespace Mediapipe.Net.Gpu
         ///   However, IL2CPP does not support marshaling delegates that point to instance methods to native code,
         ///   so it receives also the texture name to specify the target instance.
         /// </remarks>
-        public delegate void DeletionCallback(uint name, IntPtr glSyncToken);
+        public delegate void DeletionCallback(uint name, void* glSyncToken);
 
-        public GlTextureBuffer(IntPtr ptr, bool isOwner = true) : base(isOwner)
+        public GlTextureBuffer(void* ptr, bool isOwner = true) : base(isOwner)
         {
             sharedPtrHandle = new SharedGlTextureBufferPtr(ptr, isOwner);
             Ptr = sharedPtrHandle.Get();
@@ -32,7 +32,7 @@ namespace Mediapipe.Net.Gpu
         public GlTextureBuffer(uint target, uint name, int width, int height,
             GpuBufferFormat format, DeletionCallback callback, GlContext? glContext)
         {
-            var sharedContextPtr = glContext == null ? IntPtr.Zero : glContext.SharedPtr;
+            var sharedContextPtr = glContext == null ? void*.Zero : glContext.SharedPtr;
             UnsafeNativeMethods.mp_SharedGlTextureBuffer__ui_ui_i_i_ui_PF_PSgc(
                 target, name, width, height, format, callback, sharedContextPtr, out var ptr).Assert();
 
@@ -59,7 +59,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public IntPtr SharedPtr => sharedPtrHandle == null ? IntPtr.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
 
         public uint Name() => SafeNativeMethods.mp_GlTextureBuffer__name(MpPtr);
 
@@ -90,11 +90,11 @@ namespace Mediapipe.Net.Gpu
         // TODO: Put it in its own file
         private class SharedGlTextureBufferPtr : SharedPtrHandle
         {
-            public SharedGlTextureBufferPtr(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+            public SharedGlTextureBufferPtr(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
             protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_SharedGlTextureBuffer__delete(Ptr);
 
-            public override IntPtr Get() => SafeNativeMethods.mp_SharedGlTextureBuffer__get(MpPtr);
+            public override void* Get() => SafeNativeMethods.mp_SharedGlTextureBuffer__get(MpPtr);
 
             public override void Reset() => UnsafeNativeMethods.mp_SharedGlTextureBuffer__reset(MpPtr);
         }

--- a/Mediapipe.Net/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Gpu/GlTextureBuffer.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Native;
 

--- a/Mediapipe.Net/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Gpu/GlTextureBuffer.cs
@@ -32,7 +32,7 @@ namespace Mediapipe.Net.Gpu
         public GlTextureBuffer(uint target, uint name, int width, int height,
             GpuBufferFormat format, DeletionCallback callback, GlContext? glContext)
         {
-            var sharedContextPtr = glContext == null ? void*.Zero : glContext.SharedPtr;
+            var sharedContextPtr = glContext == null ? null : glContext.SharedPtr;
             UnsafeNativeMethods.mp_SharedGlTextureBuffer__ui_ui_i_i_ui_PF_PSgc(
                 target, name, width, height, format, callback, sharedContextPtr, out var ptr).Assert();
 
@@ -59,7 +59,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? null : sharedPtrHandle.MpPtr;
 
         public uint Name() => SafeNativeMethods.mp_GlTextureBuffer__name(MpPtr);
 

--- a/Mediapipe.Net/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Gpu/GpuBuffer.cs
@@ -11,7 +11,7 @@ namespace Mediapipe.Net.Gpu
 {
     public class GpuBuffer : MpResourceHandle
     {
-        public GpuBuffer(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+        public GpuBuffer(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         public GpuBuffer(GlTextureBuffer glTextureBuffer) : base()

--- a/Mediapipe.Net/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Gpu/GpuBuffer.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.Versioning;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Native;

--- a/Mediapipe.Net/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Gpu/GpuBuffer.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GpuBuffer : MpResourceHandle
+    public unsafe class GpuBuffer : MpResourceHandle
     {
         public GpuBuffer(void* ptr, bool isOwner = true) : base(ptr, isOwner) { }
 

--- a/Mediapipe.Net/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Gpu/GpuResources.cs
@@ -15,7 +15,7 @@ namespace Mediapipe.Net.Gpu
         private SharedPtrHandle? sharedPtrHandle;
 
         /// <param name="ptr">Shared pointer of mediapipe::GpuResources</param>
-        public GpuResources(IntPtr ptr) : base()
+        public GpuResources(void* ptr) : base()
         {
             sharedPtrHandle = new SharedGpuResourcesPtr(ptr);
             Ptr = sharedPtrHandle.Get();
@@ -36,7 +36,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public IntPtr SharedPtr => sharedPtrHandle == null ? IntPtr.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
 
         public static StatusOrGpuResources Create()
         {
@@ -45,7 +45,7 @@ namespace Mediapipe.Net.Gpu
             return new StatusOrGpuResources(statusOrGpuResourcesPtr);
         }
 
-        public static StatusOrGpuResources Create(IntPtr externalContext)
+        public static StatusOrGpuResources Create(void* externalContext)
         {
             UnsafeNativeMethods.mp_GpuResources_Create__Pv(externalContext, out var statusOrGpuResourcesPtr).Assert();
 
@@ -53,15 +53,15 @@ namespace Mediapipe.Net.Gpu
         }
 
         [SupportedOSPlatform("IOS")]
-        public IntPtr IosGpuData => SafeNativeMethods.mp_GpuResources__ios_gpu_data(MpPtr);
+        public void* IosGpuData => SafeNativeMethods.mp_GpuResources__ios_gpu_data(MpPtr);
 
         private class SharedGpuResourcesPtr : SharedPtrHandle
         {
-            public SharedGpuResourcesPtr(IntPtr ptr) : base(ptr) { }
+            public SharedGpuResourcesPtr(void* ptr) : base(ptr) { }
 
             protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_SharedGpuResources__delete(Ptr);
 
-            public override IntPtr Get() => SafeNativeMethods.mp_SharedGpuResources__get(MpPtr);
+            public override void* Get() => SafeNativeMethods.mp_SharedGpuResources__get(MpPtr);
 
             public override void Reset() => UnsafeNativeMethods.mp_SharedGpuResources__reset(MpPtr);
         }

--- a/Mediapipe.Net/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Gpu/GpuResources.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Gpu
 {
-    public class GpuResources : MpResourceHandle
+    public unsafe class GpuResources : MpResourceHandle
     {
         private SharedPtrHandle? sharedPtrHandle;
 

--- a/Mediapipe.Net/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Gpu/GpuResources.cs
@@ -36,7 +36,7 @@ namespace Mediapipe.Net.Gpu
             // Do nothing
         }
 
-        public void* SharedPtr => sharedPtrHandle == null ? void*.Zero : sharedPtrHandle.MpPtr;
+        public void* SharedPtr => sharedPtrHandle == null ? null : sharedPtrHandle.MpPtr;
 
         public static StatusOrGpuResources Create()
         {

--- a/Mediapipe.Net/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Gpu/GpuResources.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.Versioning;
 using Mediapipe.Net.Core;
 using Mediapipe.Net.Framework.Port;

--- a/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
+++ b/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
@@ -20,7 +20,6 @@ namespace Mediapipe.Net.Graphs.InstantMotionTracking
         public List<Anchor3d> ToList()
         {
             var anchors = new List<Anchor3d>(Size);
-
             for (int i = 0; i < Size; i++)
                 anchors.Add(Data[i]);
 

--- a/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
+++ b/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
@@ -21,9 +21,8 @@ namespace Mediapipe.Net.Graphs.InstantMotionTracking
         {
             var anchors = new List<Anchor3d>(Size);
 
-            var anchorPtr = Data;
-            for (var i = 0; i < Size; i++)
-                anchors.Add(*anchorPtr++);
+            for (int i = 0; i < Size; i++)
+                anchors.Add(Data[i]);
 
             return anchors;
         }

--- a/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
+++ b/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Graphs.InstantMotionTracking
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct Anchor3dVector : IDisposable
     {
-        public void* Data;
+        public Anchor3d* Data;
         public int Size;
 
         public void Dispose() => UnsafeNativeMethods.mp_Anchor3dArray__delete(Data);
@@ -21,13 +21,9 @@ namespace Mediapipe.Net.Graphs.InstantMotionTracking
         {
             var anchors = new List<Anchor3d>(Size);
 
-            unsafe
-            {
-                var anchorPtr = (Anchor3d*)Data;
-
-                for (var i = 0; i < Size; i++)
-                    anchors.Add(Marshal.PtrToStructure<Anchor3d>((void*)anchorPtr++));
-            }
+            var anchorPtr = Data;
+            for (var i = 0; i < Size; i++)
+                anchors.Add(*anchorPtr++);
 
             return anchors;
         }

--- a/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
+++ b/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Native;
 namespace Mediapipe.Net.Graphs.InstantMotionTracking
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct Anchor3dVector : IDisposable
+    internal unsafe struct Anchor3dVector : IDisposable
     {
         public void* Data;
         public int Size;

--- a/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
+++ b/Mediapipe.Net/Graphs/InstantMotionTracking/Anchor3dVector.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Graphs.InstantMotionTracking
     [StructLayout(LayoutKind.Sequential)]
     internal struct Anchor3dVector : IDisposable
     {
-        public IntPtr Data;
+        public void* Data;
         public int Size;
 
         public void Dispose() => UnsafeNativeMethods.mp_Anchor3dArray__delete(Data);
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Graphs.InstantMotionTracking
                 var anchorPtr = (Anchor3d*)Data;
 
                 for (var i = 0; i < Size; i++)
-                    anchors.Add(Marshal.PtrToStructure<Anchor3d>((IntPtr)anchorPtr++));
+                    anchors.Add(Marshal.PtrToStructure<Anchor3d>((void*)anchorPtr++));
             }
 
             return anchors;

--- a/Mediapipe.Net/Native/NativeMethods.cs
+++ b/Mediapipe.Net/Native/NativeMethods.cs
@@ -4,10 +4,6 @@
 
 namespace Mediapipe.Net.Native
 {
-    // TODO: (message to future self) Beware of CharSet.Unicode!
-    // If tests fail because of odd string issues, try to marshal strings according to
-    // https://docs.microsoft.com/en-us/dotnet/standard/native-interop/type-marshaling.
-
     /// <summary>
     /// Contains all the directly bound native methods from Mediapipe.
     /// </summary>

--- a/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern bool absl_Status__ok(void* status);

--- a/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
@@ -11,7 +11,6 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool absl_Status__ok(IntPtr status);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
@@ -11,9 +11,9 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool absl_Status__ok(IntPtr status);
+        public static extern bool absl_Status__ok(void* status);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int absl_Status__raw_code(IntPtr status);
+        public static extern int absl_Status__raw_code(void* status);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/External/Absl.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Native
     internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool absl_Status__ok(void* status);
+        public static extern byte absl_Status__ok(void* status);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern int absl_Status__raw_code(void* status);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
 #pragma warning disable CA2101
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
@@ -11,19 +11,19 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__HasError(void* graph);
+        public static extern byte mp_CalculatorGraph__HasError(void* graph);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern bool mp_CalculatorGraph__HasInputStream__PKc(void* graph, string name);
+        public static extern byte mp_CalculatorGraph__HasInputStream__PKc(void* graph, string name);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__GraphInputStreamsClosed(void* graph);
+        public static extern byte mp_CalculatorGraph__GraphInputStreamsClosed(void* graph);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__IsNodeThrottled__i(void* graph, int nodeId);
+        public static extern byte mp_CalculatorGraph__IsNodeThrottled__i(void* graph, int nodeId);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__UnthrottleSources(void* graph);
+        public static extern byte mp_CalculatorGraph__UnthrottleSources(void* graph);
 #pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
@@ -12,23 +12,18 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__HasError(IntPtr graph);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__HasInputStream__PKc(IntPtr graph, string name);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__GraphInputStreamsClosed(IntPtr graph);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__IsNodeThrottled__i(IntPtr graph, int nodeId);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_CalculatorGraph__UnthrottleSources(IntPtr graph);
 #pragma warning restore CA2101
     }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/CalculatorGraph.cs
@@ -12,19 +12,19 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__HasError(IntPtr graph);
+        public static extern bool mp_CalculatorGraph__HasError(void* graph);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern bool mp_CalculatorGraph__HasInputStream__PKc(IntPtr graph, string name);
+        public static extern bool mp_CalculatorGraph__HasInputStream__PKc(void* graph, string name);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__GraphInputStreamsClosed(IntPtr graph);
+        public static extern bool mp_CalculatorGraph__GraphInputStreamsClosed(void* graph);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__IsNodeThrottled__i(IntPtr graph, int nodeId);
+        public static extern bool mp_CalculatorGraph__IsNodeThrottled__i(void* graph, int nodeId);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_CalculatorGraph__UnthrottleSources(IntPtr graph);
+        public static extern bool mp_CalculatorGraph__UnthrottleSources(void* graph);
 #pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -12,11 +12,9 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_ImageFrame__IsEmpty(IntPtr imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_ImageFrame__IsContiguous(IntPtr imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
@@ -55,7 +53,6 @@ namespace Mediapipe.Net.Native
 
         #region StatusOr
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_StatusOrImageFrame__ok(IntPtr statusOrImageFrame);
         #endregion
     }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -21,7 +21,7 @@ namespace Mediapipe.Net.Native
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__IsAligned__ui(
-            IntPtr imageFrame, uint alignmentBoundary, [MarshalAs(UnmanagedType.I1)] out bool value);
+            IntPtr imageFrame, uint alignmentBoundary, out bool value);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern ImageFormat mp_ImageFrame__Format(IntPtr imageFrame);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Framework.Format;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern bool mp_ImageFrame__IsEmpty(void* imageFrame);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.Framework.Format;

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -12,48 +12,48 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_ImageFrame__IsEmpty(IntPtr imageFrame);
+        public static extern bool mp_ImageFrame__IsEmpty(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_ImageFrame__IsContiguous(IntPtr imageFrame);
+        public static extern bool mp_ImageFrame__IsContiguous(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__IsAligned__ui(
-            IntPtr imageFrame, uint alignmentBoundary, out bool value);
+            void* imageFrame, uint alignmentBoundary, out bool value);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern ImageFormat mp_ImageFrame__Format(IntPtr imageFrame);
+        public static extern ImageFormat mp_ImageFrame__Format(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_ImageFrame__Width(IntPtr imageFrame);
+        public static extern int mp_ImageFrame__Width(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_ImageFrame__Height(IntPtr imageFrame);
+        public static extern int mp_ImageFrame__Height(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__ChannelSize(IntPtr imageFrame, out int value);
+        public static extern MpReturnCode mp_ImageFrame__ChannelSize(void* imageFrame, out int value);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__NumberOfChannels(IntPtr imageFrame, out int value);
+        public static extern MpReturnCode mp_ImageFrame__NumberOfChannels(void* imageFrame, out int value);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__ByteDepth(IntPtr imageFrame, out int value);
+        public static extern MpReturnCode mp_ImageFrame__ByteDepth(void* imageFrame, out int value);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_ImageFrame__WidthStep(IntPtr imageFrame);
+        public static extern int mp_ImageFrame__WidthStep(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_ImageFrame__MutablePixelData(IntPtr imageFrame);
+        public static extern void* mp_ImageFrame__MutablePixelData(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_ImageFrame__PixelDataSize(IntPtr imageFrame);
+        public static extern int mp_ImageFrame__PixelDataSize(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__PixelDataSizeStoredContiguously(IntPtr imageFrame, out int value);
+        public static extern MpReturnCode mp_ImageFrame__PixelDataSizeStoredContiguously(void* imageFrame, out int value);
 
         #region StatusOr
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrImageFrame__ok(IntPtr statusOrImageFrame);
+        public static extern bool mp_StatusOrImageFrame__ok(void* statusOrImageFrame);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -42,7 +42,7 @@ namespace Mediapipe.Net.Native
         public static extern int mp_ImageFrame__WidthStep(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void* mp_ImageFrame__MutablePixelData(void* imageFrame);
+        public static extern byte* mp_ImageFrame__MutablePixelData(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern int mp_ImageFrame__PixelDataSize(void* imageFrame);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -11,10 +11,10 @@ namespace Mediapipe.Net.Native
     internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_ImageFrame__IsEmpty(void* imageFrame);
+        public static extern byte mp_ImageFrame__IsEmpty(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_ImageFrame__IsContiguous(void* imageFrame);
+        public static extern byte mp_ImageFrame__IsContiguous(void* imageFrame);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__IsAligned__ui(
@@ -52,7 +52,7 @@ namespace Mediapipe.Net.Native
 
         #region StatusOr
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrImageFrame__ok(void* statusOrImageFrame);
+        public static extern byte mp_StatusOrImageFrame__ok(void* statusOrImageFrame);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern bool mp_StatusOrPoller__ok(void* statusOrPoller);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -11,7 +11,6 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_StatusOrPoller__ok(IntPtr statusOrPoller);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -11,6 +11,6 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrPoller__ok(IntPtr statusOrPoller);
+        public static extern bool mp_StatusOrPoller__ok(void* statusOrPoller);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -10,6 +10,6 @@ namespace Mediapipe.Net.Native
     internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrPoller__ok(void* statusOrPoller);
+        public static extern byte mp_StatusOrPoller__ok(void* statusOrPoller);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
@@ -10,7 +10,7 @@ namespace Mediapipe.Net.Native
     internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Packet__IsEmpty(void* packet);
+        public static extern byte mp_Packet__IsEmpty(void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_SidePacket__clear(void* sidePacket);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
@@ -11,12 +11,12 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Packet__IsEmpty(IntPtr packet);
+        public static extern bool mp_Packet__IsEmpty(void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SidePacket__clear(IntPtr sidePacket);
+        public static extern void mp_SidePacket__clear(void* sidePacket);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_SidePacket__size(IntPtr sidePacket);
+        public static extern int mp_SidePacket__size(void* sidePacket);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern bool mp_Packet__IsEmpty(void* packet);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Packet.cs
@@ -11,7 +11,6 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_Packet__IsEmpty(IntPtr packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
@@ -11,21 +11,21 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern long mp_Timestamp__Value(IntPtr timestamp);
+        public static extern long mp_Timestamp__Value(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern double mp_Timestamp__Seconds(IntPtr timestamp);
+        public static extern double mp_Timestamp__Seconds(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern long mp_Timestamp__Microseconds(IntPtr timestamp);
+        public static extern long mp_Timestamp__Microseconds(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Timestamp__IsSpecialValue(IntPtr timestamp);
+        public static extern bool mp_Timestamp__IsSpecialValue(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Timestamp__IsRangeValue(IntPtr timestamp);
+        public static extern bool mp_Timestamp__IsRangeValue(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Timestamp__IsAllowedInStream(IntPtr timestamp);
+        public static extern bool mp_Timestamp__IsAllowedInStream(void* timestamp);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
@@ -19,12 +19,12 @@ namespace Mediapipe.Net.Native
         public static extern long mp_Timestamp__Microseconds(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Timestamp__IsSpecialValue(void* timestamp);
+        public static extern byte mp_Timestamp__IsSpecialValue(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Timestamp__IsRangeValue(void* timestamp);
+        public static extern byte mp_Timestamp__IsRangeValue(void* timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_Timestamp__IsAllowedInStream(void* timestamp);
+        public static extern byte mp_Timestamp__IsAllowedInStream(void* timestamp);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
@@ -20,15 +20,12 @@ namespace Mediapipe.Net.Native
         public static extern long mp_Timestamp__Microseconds(IntPtr timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_Timestamp__IsSpecialValue(IntPtr timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_Timestamp__IsRangeValue(IntPtr timestamp);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_Timestamp__IsAllowedInStream(IntPtr timestamp);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Framework/Timestamp.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern long mp_Timestamp__Value(void* timestamp);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/Gl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/Gl.cs
@@ -9,7 +9,7 @@ using System.Runtime.Versioning;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/Gl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/Gl.cs
@@ -13,6 +13,6 @@ namespace Mediapipe.Net.Native
     {
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY)]
-        public static extern IntPtr eglGetCurrentContext();
+        public static extern void* eglGetCurrentContext();
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/Gl.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/Gl.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -17,7 +17,6 @@ namespace Mediapipe.Net.Native
         public static extern IntPtr mp_GlCalculatorHelper__GetGlContext(IntPtr glCalculatorHelper);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_GlCalculatorHelper__Initialized(IntPtr glCalculatorHelper);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -11,12 +11,12 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern uint mp_GlCalculatorHelper__framebuffer(IntPtr glCalculatorHelper);
+        public static extern uint mp_GlCalculatorHelper__framebuffer(void* glCalculatorHelper);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlCalculatorHelper__GetGlContext(IntPtr glCalculatorHelper);
+        public static extern void* mp_GlCalculatorHelper__GetGlContext(void* glCalculatorHelper);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_GlCalculatorHelper__Initialized(IntPtr glCalculatorHelper);
+        public static extern bool mp_GlCalculatorHelper__Initialized(void* glCalculatorHelper);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -16,6 +16,6 @@ namespace Mediapipe.Net.Native
         public static extern void* mp_GlCalculatorHelper__GetGlContext(void* glCalculatorHelper);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_GlCalculatorHelper__Initialized(void* glCalculatorHelper);
+        public static extern byte mp_GlCalculatorHelper__Initialized(void* glCalculatorHelper);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern uint mp_GlCalculatorHelper__framebuffer(void* glCalculatorHelper);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
@@ -9,7 +9,7 @@ using System.Runtime.Versioning;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         #region GlContext
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
@@ -40,7 +40,6 @@ namespace Mediapipe.Net.Native
         public static extern IntPtr mp_GlContext__nsgl_pixel_format(IntPtr glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_GlContext__IsCurrent(IntPtr glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
@@ -13,48 +13,48 @@ namespace Mediapipe.Net.Native
     {
         #region GlContext
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_SharedGlContext__get(IntPtr sharedGlContext);
+        public static extern void* mp_SharedGlContext__get(void* sharedGlContext);
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlContext__egl_display(IntPtr glContext);
+        public static extern void* mp_GlContext__egl_display(void* glContext);
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlContext__egl_config(IntPtr glContext);
+        public static extern void* mp_GlContext__egl_config(void* glContext);
 
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlContext__egl_context(IntPtr glContext);
+        public static extern void* mp_GlContext__egl_context(void* glContext);
 
         [SupportedOSPlatform("IOS")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlContext__eagl_context(IntPtr glContext);
+        public static extern void* mp_GlContext__eagl_context(void* glContext);
 
         [SupportedOSPlatform("OSX")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlContext__nsgl_context(IntPtr glContext);
+        public static extern void* mp_GlContext__nsgl_context(void* glContext);
 
         [SupportedOSPlatform("OSX")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlContext__nsgl_pixel_format(IntPtr glContext);
+        public static extern void* mp_GlContext__nsgl_pixel_format(void* glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_GlContext__IsCurrent(IntPtr glContext);
+        public static extern bool mp_GlContext__IsCurrent(void* glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GlContext__gl_major_version(IntPtr glContext);
+        public static extern int mp_GlContext__gl_major_version(void* glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GlContext__gl_minor_version(IntPtr glContext);
+        public static extern int mp_GlContext__gl_minor_version(void* glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern long mp_GlContext__gl_finish_count(IntPtr glContext);
+        public static extern long mp_GlContext__gl_finish_count(void* glContext);
         #endregion
 
         #region GlSyncToken
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlSyncToken__get(IntPtr glSyncToken);
+        public static extern void* mp_GlSyncToken__get(void* glSyncToken);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlContext.cs
@@ -39,7 +39,7 @@ namespace Mediapipe.Net.Native
         public static extern void* mp_GlContext__nsgl_pixel_format(void* glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_GlContext__IsCurrent(void* glContext);
+        public static extern byte mp_GlContext__IsCurrent(void* glContext);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern int mp_GlContext__gl_major_version(void* glContext);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTexture.cs
@@ -11,15 +11,15 @@ namespace Mediapipe.Net.Native
     internal partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GlTexture__width(IntPtr glTexture);
+        public static extern int mp_GlTexture__width(void* glTexture);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GlTexture__height(IntPtr glTexture);
+        public static extern int mp_GlTexture__height(void* glTexture);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern uint mp_GlTexture__target(IntPtr glTexture);
+        public static extern uint mp_GlTexture__target(void* glTexture);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern uint mp_GlTexture__name(IntPtr glTexture);
+        public static extern uint mp_GlTexture__name(void* glTexture);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTexture.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTexture.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern int mp_GlTexture__width(void* glTexture);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.Gpu;

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -13,27 +13,27 @@ namespace Mediapipe.Net.Native
     {
         #region GlTextureBuffer
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern uint mp_GlTextureBuffer__name(IntPtr glTextureBuffer);
+        public static extern uint mp_GlTextureBuffer__name(void* glTextureBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern uint mp_GlTextureBuffer__target(IntPtr glTextureBuffer);
+        public static extern uint mp_GlTextureBuffer__target(void* glTextureBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GlTextureBuffer__width(IntPtr glTextureBuffer);
+        public static extern int mp_GlTextureBuffer__width(void* glTextureBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GlTextureBuffer__height(IntPtr glTextureBuffer);
+        public static extern int mp_GlTextureBuffer__height(void* glTextureBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern GpuBufferFormat mp_GlTextureBuffer__format(IntPtr glTextureBuffer);
+        public static extern GpuBufferFormat mp_GlTextureBuffer__format(void* glTextureBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GlTextureBuffer__GetProducerContext(IntPtr glTextureBuffer);
+        public static extern void* mp_GlTextureBuffer__GetProducerContext(void* glTextureBuffer);
         #endregion
 
         #region SharedGlTextureBuffer
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_SharedGlTextureBuffer__get(IntPtr glTextureBuffer);
+        public static extern void* mp_SharedGlTextureBuffer__get(void* glTextureBuffer);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Gpu;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         #region GlTextureBuffer
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
@@ -26,7 +26,7 @@ namespace Mediapipe.Net.Native
 
         #region StatusOr
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrGpuBuffer__ok(void* statusOrGpuBuffer);
+        public static extern byte mp_StatusOrGpuBuffer__ok(void* statusOrGpuBuffer);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
@@ -27,7 +27,6 @@ namespace Mediapipe.Net.Native
 
         #region StatusOr
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_StatusOrGpuBuffer__ok(IntPtr statusOrGpuBuffer);
         #endregion
     }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
@@ -10,7 +10,7 @@ using Mediapipe.Net.Gpu;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBuffer.cs
@@ -14,20 +14,20 @@ namespace Mediapipe.Net.Native
     {
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GpuBuffer__GetGlTextureBufferSharedPtr(IntPtr gpuBuffer);
+        public static extern void* mp_GpuBuffer__GetGlTextureBufferSharedPtr(void* gpuBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GpuBuffer__width(IntPtr gpuBuffer);
+        public static extern int mp_GpuBuffer__width(void* gpuBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern int mp_GpuBuffer__height(IntPtr gpuBuffer);
+        public static extern int mp_GpuBuffer__height(void* gpuBuffer);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern GpuBufferFormat mp_GpuBuffer__format(IntPtr gpuBuffer);
+        public static extern GpuBufferFormat mp_GpuBuffer__format(void* gpuBuffer);
 
         #region StatusOr
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrGpuBuffer__ok(IntPtr statusOrGpuBuffer);
+        public static extern bool mp_StatusOrGpuBuffer__ok(void* statusOrGpuBuffer);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBufferFormat.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuBufferFormat.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Gpu;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern ImageFormat mp__ImageFormatForGpuBufferFormat__ui(GpuBufferFormat format);

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
@@ -13,12 +13,12 @@ namespace Mediapipe.Net.Native
     {
         [SupportedOSPlatform("IOS")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_GpuResources__ios_gpu_data(IntPtr gpuResources);
+        public static extern void* mp_GpuResources__ios_gpu_data(void* gpuResources);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern IntPtr mp_SharedGpuResources__get(IntPtr gpuResources);
+        public static extern void* mp_SharedGpuResources__get(void* gpuResources);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrGpuResources__ok(IntPtr statusOrGpuResources);
+        public static extern bool mp_StatusOrGpuResources__ok(void* statusOrGpuResources);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
@@ -19,7 +19,6 @@ namespace Mediapipe.Net.Native
         public static extern IntPtr mp_SharedGpuResources__get(IntPtr gpuResources);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_StatusOrGpuResources__ok(IntPtr statusOrGpuResources);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
@@ -9,7 +9,7 @@ using System.Runtime.Versioning;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [SupportedOSPlatform("IOS")]
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Gpu/GpuResources.cs
@@ -18,6 +18,6 @@ namespace Mediapipe.Net.Native
         public static extern void* mp_SharedGpuResources__get(void* gpuResources);
 
         [Pure, DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern bool mp_StatusOrGpuResources__ok(void* statusOrGpuResources);
+        public static extern byte mp_StatusOrGpuResources__ok(void* statusOrGpuResources);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
@@ -11,10 +11,10 @@ namespace Mediapipe.Net.Native
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp__SetCustomGlobalResourceProvider__P(
-            [MarshalAs(UnmanagedType.FunctionPtr)] ResourceManager.ResourceProvider provider);
+            ResourceManager.ResourceProvider provider);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp__SetCustomGlobalPathResolver__P(
-            [MarshalAs(UnmanagedType.FunctionPtr)] ResourceManager.PathResolver resolver);
+            ResourceManager.PathResolver resolver);
     }
 }

--- a/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
@@ -7,7 +7,7 @@ using Mediapipe.Net.Util;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class SafeNativeMethods : NativeMethods
+    internal unsafe partial class SafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp__SetCustomGlobalResourceProvider__P(

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
@@ -11,13 +11,13 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode absl_Status__i_PKc(int code, string message, out IntPtr status);
+        public static extern MpReturnCode absl_Status__i_PKc(int code, string message, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void absl_Status__delete(IntPtr status);
+        public static extern void absl_Status__delete(void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode absl_Status__ToString(IntPtr status, out IntPtr str);
+        public static extern MpReturnCode absl_Status__ToString(void* status, out void* str);
 #pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Absl.cs
@@ -16,7 +16,7 @@ namespace Mediapipe.Net.Native
         public static extern void absl_Status__delete(void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode absl_Status__ToString(void* status, out void* str);
+        public static extern MpReturnCode absl_Status__ToString(void* status, out sbyte* str);
 #pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Glog.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Glog.cs
@@ -17,7 +17,7 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode google_ShutdownGoogleLogging();
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void glog_FLAGS_logtostderr([MarshalAs(UnmanagedType.I1)] bool value);
+        public static extern void glog_FLAGS_logtostderr(bool value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void glog_FLAGS_stderrthreshold(int threshold);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Glog.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Glog.cs
@@ -7,7 +7,7 @@ using Mediapipe.Net.External;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.External;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode google_protobuf__SetLogHandler__PF(

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
@@ -12,7 +12,7 @@ namespace Mediapipe.Net.Native
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode google_protobuf__SetLogHandler__PF(
-            [MarshalAs(UnmanagedType.FunctionPtr)] Protobuf.ProtobufLogHandler logHandler);
+            Protobuf.ProtobufLogHandler logHandler);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_api_SerializedProtoArray__delete(IntPtr serializedProtoVectorData);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.External;
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Protobuf.cs
@@ -15,56 +15,56 @@ namespace Mediapipe.Net.Native
             Protobuf.ProtobufLogHandler logHandler);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_api_SerializedProtoArray__delete(IntPtr serializedProtoVectorData);
+        public static extern void mp_api_SerializedProtoArray__delete(void* serializedProtoVectorData);
 
         #region MessageProto
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetClassificationList(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetClassificationList(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetClassificationListVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetClassificationListVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetDetection(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetDetection(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetDetectionVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetDetectionVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetFaceGeometry(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetFaceGeometry(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetFaceGeometryVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetFaceGeometryVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetFrameAnnotation(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetFrameAnnotation(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetLandmarkList(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetLandmarkList(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetLandmarkListVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetLandmarkListVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetNormalizedLandmarkList(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetNormalizedLandmarkList(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetNormalizedLandmarkListVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetNormalizedLandmarkListVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetNormalizedRect(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetNormalizedRect(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetNormalizedRectVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetNormalizedRectVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetRect(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetRect(void* packet, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetRectVector(IntPtr packet, out SerializedProtoVector serializedProtoVector);
+        public static extern MpReturnCode mp_Packet__GetRectVector(void* packet, out SerializedProtoVector serializedProtoVector);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetTimedModelMatrixProtoList(IntPtr packet, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_Packet__GetTimedModelMatrixProtoList(void* packet, out SerializedProto serializedProto);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
@@ -10,17 +10,17 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void delete_array__PKc(IntPtr str);
+        public static extern void delete_array__PKc(void* str);
 
         #region String
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void std_string__delete(IntPtr str);
+        public static extern void std_string__delete(void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode std_string__PKc_i(byte[] bytes, int size, out IntPtr str);
+        public static extern MpReturnCode std_string__PKc_i(byte[] bytes, int size, out void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void std_string__swap__Rstr(IntPtr src, IntPtr dst);
+        public static extern void std_string__swap__Rstr(void* src, void* dst);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
@@ -9,14 +9,14 @@ namespace Mediapipe.Net.Native
     internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void delete_array__PKc(void* str);
+        public static extern void delete_array__PKc(sbyte* str);
 
         #region String
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void std_string__delete(void* str);
+        public static extern void std_string__delete(sbyte* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode std_string__PKc_i(byte[] bytes, int size, out void* str);
+        public static extern MpReturnCode std_string__PKc_i(byte[] bytes, int size, out sbyte* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void std_string__swap__Rstr(void* src, void* dst);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void delete_array__PKc(void* str);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
@@ -11,7 +11,6 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool mp_api__ConvertFromCalculatorGraphConfigTextFormat(string configText, out SerializedProto serializedProto);
 #pragma warning restore CA2101
     }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
@@ -7,7 +7,7 @@ using Mediapipe.Net.External;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Calculator.cs
@@ -11,7 +11,7 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern bool mp_api__ConvertFromCalculatorGraphConfigTextFormat(string configText, out SerializedProto serializedProto);
+        public static extern byte mp_api__ConvertFromCalculatorGraphConfigTextFormat(string configText, out SerializedProto serializedProto);
 #pragma warning restore CA2101
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.External;
 using Mediapipe.Net.Framework;

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Framework;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -37,10 +37,11 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(IntPtr graph, string streamName,
             [MarshalAs(UnmanagedType.FunctionPtr)] CalculatorGraph.NativePacketCallback packetCallback,
-            [MarshalAs(UnmanagedType.I1)] bool observeTimestampBounds, out IntPtr status);
+            bool observeTimestampBounds, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_CalculatorGraph__AddOutputStreamPoller__PKc_b(IntPtr graph, string streamName, [MarshalAs(UnmanagedType.I1)] bool observeTimestampBounds, out IntPtr statusOrPoller);
+        public static extern MpReturnCode mp_CalculatorGraph__AddOutputStreamPoller__PKc_b(IntPtr graph, string streamName,
+            bool observeTimestampBounds, out IntPtr statusOrPoller);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__Run__Rsp(IntPtr graph, IntPtr sidePackets, out IntPtr status);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -36,7 +36,7 @@ namespace Mediapipe.Net.Native
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(IntPtr graph, string streamName,
-            [MarshalAs(UnmanagedType.FunctionPtr)] CalculatorGraph.NativePacketCallback packetCallback,
+            CalculatorGraph.NativePacketCallback packetCallback,
             bool observeTimestampBounds, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/CalculatorGraph.cs
@@ -13,71 +13,71 @@ namespace Mediapipe.Net.Native
     {
 #pragma warning disable CA2101
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__(out IntPtr graph);
+        public static extern MpReturnCode mp_CalculatorGraph__(out void* graph);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_CalculatorGraph__PKc(string textFormatConfig, out IntPtr graph);
+        public static extern MpReturnCode mp_CalculatorGraph__PKc(string textFormatConfig, out void* graph);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__PKc_i(byte[] serializedConfig, int size, out IntPtr graph);
+        public static extern MpReturnCode mp_CalculatorGraph__PKc_i(byte[] serializedConfig, int size, out void* graph);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_CalculatorGraph__delete(IntPtr graph);
+        public static extern void mp_CalculatorGraph__delete(void* graph);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__Initialize__PKc_i(IntPtr graph, byte[] serializedConfig, int size, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__Initialize__PKc_i(void* graph, byte[] serializedConfig, int size, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_CalculatorGraph__Initialize__PKc_i_Rsp(
-            IntPtr graph, byte[] serializedConfig, int size, IntPtr sidePackets, out IntPtr status);
+            void* graph, byte[] serializedConfig, int size, void* sidePackets, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__Config(IntPtr graph, out SerializedProto serializedProto);
+        public static extern MpReturnCode mp_CalculatorGraph__Config(void* graph, out SerializedProto serializedProto);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(IntPtr graph, string streamName,
+        public static extern MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(void* graph, string streamName,
             CalculatorGraph.NativePacketCallback packetCallback,
-            bool observeTimestampBounds, out IntPtr status);
+            bool observeTimestampBounds, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_CalculatorGraph__AddOutputStreamPoller__PKc_b(IntPtr graph, string streamName,
-            bool observeTimestampBounds, out IntPtr statusOrPoller);
+        public static extern MpReturnCode mp_CalculatorGraph__AddOutputStreamPoller__PKc_b(void* graph, string streamName,
+            bool observeTimestampBounds, out void* statusOrPoller);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__Run__Rsp(IntPtr graph, IntPtr sidePackets, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__Run__Rsp(void* graph, void* sidePackets, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__StartRun__Rsp(IntPtr graph, IntPtr sidePackets, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__StartRun__Rsp(void* graph, void* sidePackets, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__WaitUntilIdle(IntPtr graph, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__WaitUntilIdle(void* graph, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__WaitUntilDone(IntPtr graph, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__WaitUntilDone(void* graph, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__AddPacketToInputStream__PKc_Ppacket(
-            IntPtr graph, string streamName, IntPtr packet, out IntPtr status);
+            void* graph, string streamName, void* packet, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
         public static extern MpReturnCode mp_CalculatorGraph__SetInputStreamMaxQueueSize__PKc_i(
-            IntPtr graph, string streamName, int maxQueueSize, out IntPtr status);
+            void* graph, string streamName, int maxQueueSize, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_CalculatorGraph__CloseInputStream__PKc(IntPtr graph, string streamName, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__CloseInputStream__PKc(void* graph, string streamName, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__CloseAllPacketSources(IntPtr graph, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__CloseAllPacketSources(void* graph, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__Cancel(IntPtr graph);
+        public static extern MpReturnCode mp_CalculatorGraph__Cancel(void* graph);
 
         #region GPU
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__GetGpuResources(IntPtr graph, out IntPtr gpuResources);
+        public static extern MpReturnCode mp_CalculatorGraph__GetGpuResources(void* graph, out void* gpuResources);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_CalculatorGraph__SetGpuResources__SPgpu(IntPtr graph, IntPtr gpuResources, out IntPtr status);
+        public static extern MpReturnCode mp_CalculatorGraph__SetGpuResources__SPgpu(void* graph, void* gpuResources, out void* status);
         #endregion
 #pragma warning restore CA2101
     }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.Framework.Format;
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -22,7 +22,7 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8_PF(
             ImageFormat format, int width, int height, int widthStep, IntPtr pixelData,
-            [MarshalAs(UnmanagedType.FunctionPtr)] Deleter deleter, out IntPtr imageFrame);
+            Deleter deleter, out IntPtr imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_ImageFrame__delete(IntPtr imageFrame);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -16,12 +16,10 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_ui(
             ImageFormat format, int width, int height, uint alignmentBoundary, out void* imageFrame);
 
-        // TODO: Make it be a member of ImageFrame
-        public delegate void Deleter(void* ptr);
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8_PF(
-            ImageFormat format, int width, int height, int widthStep, void* pixelData,
-            Deleter deleter, out void* imageFrame);
+            ImageFormat format, int width, int height, int widthStep, byte* pixelData,
+            ImageFrame.Deleter deleter, out void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_ImageFrame__delete(void* imageFrame);
@@ -33,13 +31,13 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp_ImageFrame__SetAlignmentPaddingAreas(void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui8_i(void* imageFrame, void* buffer, int bufferSize);
+        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui8_i(void* imageFrame, byte* buffer, int bufferSize);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui16_i(void* imageFrame, void* buffer, int bufferSize);
+        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui16_i(void* imageFrame, ushort* buffer, int bufferSize);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pf_i(void* imageFrame, void* buffer, int bufferSize);
+        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pf_i(void* imageFrame, float* buffer, int bufferSize);
 
         #region StatusOr
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -11,63 +11,63 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__(out IntPtr imageFrame);
+        public static extern MpReturnCode mp_ImageFrame__(out void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_ui(
-            ImageFormat format, int width, int height, uint alignmentBoundary, out IntPtr imageFrame);
+            ImageFormat format, int width, int height, uint alignmentBoundary, out void* imageFrame);
 
         // TODO: Make it be a member of ImageFrame
-        public delegate void Deleter(IntPtr ptr);
+        public delegate void Deleter(void* ptr);
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8_PF(
-            ImageFormat format, int width, int height, int widthStep, IntPtr pixelData,
-            Deleter deleter, out IntPtr imageFrame);
+            ImageFormat format, int width, int height, int widthStep, void* pixelData,
+            Deleter deleter, out void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_ImageFrame__delete(IntPtr imageFrame);
+        public static extern void mp_ImageFrame__delete(void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__SetToZero(IntPtr imageFrame);
+        public static extern MpReturnCode mp_ImageFrame__SetToZero(void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__SetAlignmentPaddingAreas(IntPtr imageFrame);
+        public static extern MpReturnCode mp_ImageFrame__SetAlignmentPaddingAreas(void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui8_i(IntPtr imageFrame, IntPtr buffer, int bufferSize);
+        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui8_i(void* imageFrame, void* buffer, int bufferSize);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui16_i(IntPtr imageFrame, IntPtr buffer, int bufferSize);
+        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pui16_i(void* imageFrame, void* buffer, int bufferSize);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pf_i(IntPtr imageFrame, IntPtr buffer, int bufferSize);
+        public static extern MpReturnCode mp_ImageFrame__CopyToBuffer__Pf_i(void* imageFrame, void* buffer, int bufferSize);
 
         #region StatusOr
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_StatusOrImageFrame__delete(IntPtr statusOrImageFrame);
+        public static extern void mp_StatusOrImageFrame__delete(void* statusOrImageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrImageFrame__status(IntPtr statusOrImageFrame, out IntPtr status);
+        public static extern MpReturnCode mp_StatusOrImageFrame__status(void* statusOrImageFrame, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrImageFrame__value(IntPtr statusOrImageFrame, out IntPtr imageFrame);
+        public static extern MpReturnCode mp_StatusOrImageFrame__value(void* statusOrImageFrame, out void* imageFrame);
         #endregion
 
         #region Packet
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeImageFramePacket__Pif(IntPtr imageFrame, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeImageFramePacket__Pif(void* imageFrame, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeImageFramePacket_At__Pif_Rt(IntPtr imageFrame, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeImageFramePacket_At__Pif_Rt(void* imageFrame, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ConsumeImageFrame(IntPtr packet, out IntPtr statusOrImageFrame);
+        public static extern MpReturnCode mp_Packet__ConsumeImageFrame(void* packet, out void* statusOrImageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetImageFrame(IntPtr packet, out IntPtr imageFrame);
+        public static extern MpReturnCode mp_Packet__GetImageFrame(void* packet, out void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsImageFrame(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsImageFrame(void* packet, out void* status);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Framework.Format;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__(out void* imageFrame);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -11,30 +11,30 @@ namespace Mediapipe.Net.Native
     {
         #region OutputStreamPoller
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_OutputStreamPoller__delete(IntPtr poller);
+        public static extern void mp_OutputStreamPoller__delete(void* poller);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_OutputStreamPoller__Reset(IntPtr poller);
+        public static extern MpReturnCode mp_OutputStreamPoller__Reset(void* poller);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_OutputStreamPoller__Next_Ppacket(IntPtr poller, IntPtr packet, out bool result);
+        public static extern MpReturnCode mp_OutputStreamPoller__Next_Ppacket(void* poller, void* packet, out bool result);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_OutputStreamPoller__SetMaxQueueSize(IntPtr poller, int queueSize);
+        public static extern MpReturnCode mp_OutputStreamPoller__SetMaxQueueSize(void* poller, int queueSize);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_OutputStreamPoller__QueueSize(IntPtr poller, out int queueSize);
+        public static extern MpReturnCode mp_OutputStreamPoller__QueueSize(void* poller, out int queueSize);
         #endregion
 
         #region StatusOrPoller
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_StatusOrPoller__delete(IntPtr statusOrPoller);
+        public static extern void mp_StatusOrPoller__delete(void* statusOrPoller);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrPoller__status(IntPtr statusOrPoller, out IntPtr status);
+        public static extern MpReturnCode mp_StatusOrPoller__status(void* statusOrPoller, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrPoller__value(IntPtr statusOrPoller, out IntPtr poller);
+        public static extern MpReturnCode mp_StatusOrPoller__value(void* statusOrPoller, out void* poller);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/OutputStreamPoller.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/OutputStreamPoller.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         #region OutputStreamPoller
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -85,7 +85,7 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp__MakeFloatArrayPacket_At__Pf_i_Rt(float[] value, int size, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetFloatArray(void* packet, out void* value);
+        public static extern MpReturnCode mp_Packet__GetFloatArray(void* packet, out float* array);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_Packet__ValidateAsFloatArray(void* packet, out void* status);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -38,13 +38,13 @@ namespace Mediapipe.Net.Native
 
         #region Bool
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeBoolPacket__b([MarshalAs(UnmanagedType.I1)] bool value, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeBoolPacket__b(bool value, out IntPtr packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeBoolPacket_At__b_Rt([MarshalAs(UnmanagedType.I1)] bool value, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeBoolPacket_At__b_Rt(bool value, IntPtr timestamp, out IntPtr packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetBool(IntPtr packet, [MarshalAs(UnmanagedType.I1)] out bool value);
+        public static extern MpReturnCode mp_Packet__GetBool(IntPtr packet, out bool value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_Packet__ValidateAsBool(IntPtr packet, out IntPtr status);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
 #pragma warning disable CA2101
         #region common

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -26,13 +26,13 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp_Packet__Timestamp(void* packet, out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__DebugString(void* packet, out void* str);
+        public static extern MpReturnCode mp_Packet__DebugString(void* packet, out sbyte* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__RegisteredTypeName(void* packet, out void* str);
+        public static extern MpReturnCode mp_Packet__RegisteredTypeName(void* packet, out sbyte* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__DebugTypeName(void* packet, out void* str);
+        public static extern MpReturnCode mp_Packet__DebugTypeName(void* packet, out sbyte* str);
         #endregion
 
         #region Bool
@@ -105,10 +105,10 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp__MakeStringPacket_At__PKc_i_Rt(byte[] bytes, int size, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetString(void* packet, out void* value);
+        public static extern MpReturnCode mp_Packet__GetString(void* packet, out sbyte* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetByteString(void* packet, out void* value, out int size);
+        public static extern MpReturnCode mp_Packet__GetByteString(void* packet, out sbyte* str, out int size);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_Packet__ValidateAsString(void* packet, out void* status);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Packet.cs
@@ -12,124 +12,124 @@ namespace Mediapipe.Net.Native
 #pragma warning disable CA2101
         #region common
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__(out IntPtr packet);
+        public static extern MpReturnCode mp_Packet__(out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_Packet__delete(IntPtr packet);
+        public static extern void mp_Packet__delete(void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__At__Rt(IntPtr packet, IntPtr timestamp, out IntPtr newPacket);
+        public static extern MpReturnCode mp_Packet__At__Rt(void* packet, void* timestamp, out void* newPacket);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsProtoMessageLite(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsProtoMessageLite(void* packet, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__Timestamp(IntPtr packet, out IntPtr timestamp);
+        public static extern MpReturnCode mp_Packet__Timestamp(void* packet, out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__DebugString(IntPtr packet, out IntPtr str);
+        public static extern MpReturnCode mp_Packet__DebugString(void* packet, out void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__RegisteredTypeName(IntPtr packet, out IntPtr str);
+        public static extern MpReturnCode mp_Packet__RegisteredTypeName(void* packet, out void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__DebugTypeName(IntPtr packet, out IntPtr str);
+        public static extern MpReturnCode mp_Packet__DebugTypeName(void* packet, out void* str);
         #endregion
 
         #region Bool
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeBoolPacket__b(bool value, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeBoolPacket__b(bool value, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeBoolPacket_At__b_Rt(bool value, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeBoolPacket_At__b_Rt(bool value, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetBool(IntPtr packet, out bool value);
+        public static extern MpReturnCode mp_Packet__GetBool(void* packet, out bool value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsBool(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsBool(void* packet, out void* status);
         #endregion
 
         #region Float
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeFloatPacket__f(float value, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeFloatPacket__f(float value, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeFloatPacket_At__f_Rt(float value, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeFloatPacket_At__f_Rt(float value, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetFloat(IntPtr packet, out float value);
+        public static extern MpReturnCode mp_Packet__GetFloat(void* packet, out float value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsFloat(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsFloat(void* packet, out void* status);
         #endregion
 
         #region Int
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeIntPacket__i(int value, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeIntPacket__i(int value, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeIntPacket_At__i_Rt(int value, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeIntPacket_At__i_Rt(int value, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetInt(IntPtr packet, out int value);
+        public static extern MpReturnCode mp_Packet__GetInt(void* packet, out int value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsInt(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsInt(void* packet, out void* status);
         #endregion
 
         #region FloatArray
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeFloatArrayPacket__Pf_i(float[] value, int size, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeFloatArrayPacket__Pf_i(float[] value, int size, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeFloatArrayPacket_At__Pf_i_Rt(float[] value, int size, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeFloatArrayPacket_At__Pf_i_Rt(float[] value, int size, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetFloatArray(IntPtr packet, out IntPtr value);
+        public static extern MpReturnCode mp_Packet__GetFloatArray(void* packet, out void* value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsFloatArray(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsFloatArray(void* packet, out void* status);
         #endregion
 
         #region String
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp__MakeStringPacket__PKc(string value, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeStringPacket__PKc(string value, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp__MakeStringPacket_At__PKc_Rt(string value, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeStringPacket_At__PKc_Rt(string value, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeStringPacket__PKc_i(byte[] bytes, int size, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeStringPacket__PKc_i(byte[] bytes, int size, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeStringPacket_At__PKc_i_Rt(byte[] bytes, int size, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeStringPacket_At__PKc_i_Rt(byte[] bytes, int size, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetString(IntPtr packet, out IntPtr value);
+        public static extern MpReturnCode mp_Packet__GetString(void* packet, out void* value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetByteString(IntPtr packet, out IntPtr value, out int size);
+        public static extern MpReturnCode mp_Packet__GetByteString(void* packet, out void* value, out int size);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsString(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsString(void* packet, out void* status);
         #endregion
 
         #region SidePacket
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_SidePacket__(out IntPtr sidePacket);
+        public static extern MpReturnCode mp_SidePacket__(out void* sidePacket);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SidePacket__delete(IntPtr sidePacket);
+        public static extern void mp_SidePacket__delete(void* sidePacket);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_SidePacket__emplace__PKc_Rp(IntPtr sidePacket, string key, IntPtr packet);
+        public static extern MpReturnCode mp_SidePacket__emplace__PKc_Rp(void* sidePacket, string key, void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_SidePacket__at__PKc(IntPtr sidePacket, string key, out IntPtr packet);
+        public static extern MpReturnCode mp_SidePacket__at__PKc(void* sidePacket, string key, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        public static extern MpReturnCode mp_SidePacket__erase__PKc(IntPtr sidePacket, string key, out int count);
+        public static extern MpReturnCode mp_SidePacket__erase__PKc(void* sidePacket, string key, out int count);
         #endregion
 #pragma warning restore CA2101
     }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
@@ -15,7 +15,7 @@ namespace Mediapipe.Net.Native
         public static extern void mp_Timestamp__delete(void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp__DebugString(void* timestamp, out void* str);
+        public static extern MpReturnCode mp_Timestamp__DebugString(void* timestamp, out sbyte* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_Timestamp__NextAllowedInStream(void* timestamp, out void* nextTimestamp);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_Timestamp__l(long value, out void* timestamp);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
@@ -10,45 +10,45 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp__l(long value, out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp__l(long value, out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_Timestamp__delete(IntPtr timestamp);
+        public static extern void mp_Timestamp__delete(void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp__DebugString(IntPtr timestamp, out IntPtr str);
+        public static extern MpReturnCode mp_Timestamp__DebugString(void* timestamp, out void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp__NextAllowedInStream(IntPtr timestamp, out IntPtr nextTimestamp);
+        public static extern MpReturnCode mp_Timestamp__NextAllowedInStream(void* timestamp, out void* nextTimestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp__PreviousAllowedInStream(IntPtr timestamp, out IntPtr prevTimestamp);
+        public static extern MpReturnCode mp_Timestamp__PreviousAllowedInStream(void* timestamp, out void* prevTimestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_FromSeconds__d(double seconds, out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_FromSeconds__d(double seconds, out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_Unset(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_Unset(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_Unstarted(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_Unstarted(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_PreStream(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_PreStream(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_Min(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_Min(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_Max(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_Max(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_PostStream(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_PostStream(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_OneOverPostStream(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_OneOverPostStream(out void* timestamp);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp_Done(out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp_Done(out void* timestamp);
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Timestamp.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/Gl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/Gl.cs
@@ -13,6 +13,6 @@ namespace Mediapipe.Net.Native
         public static extern void glFlush();
 
         [DllImport(MEDIAPIPE_LIBRARY)]
-        public static extern void glReadPixels(int x, int y, int width, int height, uint glFormat, uint glType, IntPtr pixels);
+        public static extern void glReadPixels(int x, int y, int width, int height, uint glFormat, uint glType, void* pixels);
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/Gl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/Gl.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/Gl.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/Gl.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY)]
         public static extern void glFlush();

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -12,41 +12,41 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlCalculatorHelper__(out IntPtr glCalculatorHelper);
+        public static extern MpReturnCode mp_GlCalculatorHelper__(out void* glCalculatorHelper);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_GlCalculatorHelper__delete(IntPtr glCalculatorHelper);
+        public static extern void mp_GlCalculatorHelper__delete(void* glCalculatorHelper);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlCalculatorHelper__InitializeForTest__Pgr(IntPtr glCalculatorHelper, IntPtr gpuResources);
+        public static extern MpReturnCode mp_GlCalculatorHelper__InitializeForTest__Pgr(void* glCalculatorHelper, void* gpuResources);
 
         // TODO: Make it ba a member of GlCalculatorHelper
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__RunInGlContext__PF(
-            IntPtr glCalculatorHelper, GlCalculatorHelper.NativeGlStatusFunction glFunc, out IntPtr status);
+            void* glCalculatorHelper, GlCalculatorHelper.NativeGlStatusFunction glFunc, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateSourceTexture__Rif(
-            IntPtr glCalculatorHelper, IntPtr imageFrame, out IntPtr glTexture);
+            void* glCalculatorHelper, void* imageFrame, out void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateSourceTexture__Rgb(
-            IntPtr glCalculatorHelper, IntPtr gpuBuffer, out IntPtr glTexture);
+            void* glCalculatorHelper, void* gpuBuffer, out void* glTexture);
 
         [SupportedOSPlatform("IOS")]
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateSourceTexture__Rgb_i(
-            IntPtr glCalculatorHelper, IntPtr gpuBuffer, int plane, out IntPtr glTexture);
+            void* glCalculatorHelper, void* gpuBuffer, int plane, out void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateDestinationTexture__i_i_ui(
-            IntPtr glCalculatorHelper, int outputWidth, int outputHeight, GpuBufferFormat formatCode, out IntPtr glTexture);
+            void* glCalculatorHelper, int outputWidth, int outputHeight, GpuBufferFormat formatCode, out void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateDestinationTexture__Rgb(
-            IntPtr glCalculatorHelper, IntPtr gpuBuffer, out IntPtr glTexture);
+            void* glCalculatorHelper, void* gpuBuffer, out void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlCalculatorHelper__BindFrameBuffer__Rtexture(IntPtr glCalculatorHelper, IntPtr glTexture);
+        public static extern MpReturnCode mp_GlCalculatorHelper__BindFrameBuffer__Rtexture(void* glCalculatorHelper, void* glTexture);
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -9,7 +9,7 @@ using Mediapipe.Net.Gpu;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__(out void* glCalculatorHelper);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Mediapipe.Net.Gpu;

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlCalculatorHelper.cs
@@ -23,7 +23,7 @@ namespace Mediapipe.Net.Native
         // TODO: Make it ba a member of GlCalculatorHelper
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__RunInGlContext__PF(
-            IntPtr glCalculatorHelper, [MarshalAs(UnmanagedType.FunctionPtr)] GlCalculatorHelper.NativeGlStatusFunction glFunc, out IntPtr status);
+            IntPtr glCalculatorHelper, GlCalculatorHelper.NativeGlStatusFunction glFunc, out IntPtr status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlCalculatorHelper__CreateSourceTexture__Rif(

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
@@ -8,7 +8,7 @@ using System.Runtime.Versioning;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         #region GlContext
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
@@ -12,49 +12,49 @@ namespace Mediapipe.Net.Native
     {
         #region GlContext
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SharedGlContext__delete(IntPtr sharedGlContext);
+        public static extern void mp_SharedGlContext__delete(void* sharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SharedGlContext__reset(IntPtr sharedGlContext);
+        public static extern void mp_SharedGlContext__reset(void* sharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlContext_GetCurrent(out IntPtr sharedGlContext);
+        public static extern MpReturnCode mp_GlContext_GetCurrent(out void* sharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlContext_Create__P_b(bool createThread, out IntPtr statusOrSharedGlContext);
+        public static extern MpReturnCode mp_GlContext_Create__P_b(bool createThread, out void* statusOrSharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__Rgc_b(
-            IntPtr shareContext, bool createThread, out IntPtr statusOrSharedGlContext);
+            void* shareContext, bool createThread, out void* statusOrSharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__ui_b(
-            uint shareContext, bool createThread, out IntPtr statusOrSharedGlContext);
+            uint shareContext, bool createThread, out void* statusOrSharedGlContext);
 
         [SupportedOSPlatform("IOS")]
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__Pes_b(
-            IntPtr sharegroup, bool createThread, out IntPtr statusOrSharedGlContext);
+            void* sharegroup, bool createThread, out void* statusOrSharedGlContext);
         #endregion
 
         #region GlSyncToken
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_GlSyncToken__delete(IntPtr glSyncToken);
+        public static extern void mp_GlSyncToken__delete(void* glSyncToken);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_GlSyncToken__reset(IntPtr glSyncToken);
+        public static extern void mp_GlSyncToken__reset(void* glSyncToken);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlSyncPoint__Wait(IntPtr glSyncPoint);
+        public static extern MpReturnCode mp_GlSyncPoint__Wait(void* glSyncPoint);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlSyncPoint__WaitOnGpu(IntPtr glSyncPoint);
+        public static extern MpReturnCode mp_GlSyncPoint__WaitOnGpu(void* glSyncPoint);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlSyncPoint__IsReady(IntPtr glSyncPoint, out bool value);
+        public static extern MpReturnCode mp_GlSyncPoint__IsReady(void* glSyncPoint, out bool value);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlSyncPoint__GetContext(IntPtr glSyncPoint, out IntPtr sharedGlContext);
+        public static extern MpReturnCode mp_GlSyncPoint__GetContext(void* glSyncPoint, out void* sharedGlContext);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
@@ -21,20 +21,20 @@ namespace Mediapipe.Net.Native
         public static extern MpReturnCode mp_GlContext_GetCurrent(out IntPtr sharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlContext_Create__P_b([MarshalAs(UnmanagedType.I1)] bool createThread, out IntPtr statusOrSharedGlContext);
+        public static extern MpReturnCode mp_GlContext_Create__P_b(bool createThread, out IntPtr statusOrSharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__Rgc_b(
-            IntPtr shareContext, [MarshalAs(UnmanagedType.I1)] bool createThread, out IntPtr statusOrSharedGlContext);
+            IntPtr shareContext, bool createThread, out IntPtr statusOrSharedGlContext);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__ui_b(
-            uint shareContext, [MarshalAs(UnmanagedType.I1)] bool createThread, out IntPtr statusOrSharedGlContext);
+            uint shareContext, bool createThread, out IntPtr statusOrSharedGlContext);
 
         [SupportedOSPlatform("IOS")]
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__Pes_b(
-            IntPtr sharegroup, [MarshalAs(UnmanagedType.I1)] bool createThread, out IntPtr statusOrSharedGlContext);
+            IntPtr sharegroup, bool createThread, out IntPtr statusOrSharedGlContext);
         #endregion
 
         #region GlSyncToken

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlContext.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTexture.cs
@@ -10,15 +10,15 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTexture__(out IntPtr glTexture);
+        public static extern MpReturnCode mp_GlTexture__(out void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_GlTexture__delete(IntPtr glTexture);
+        public static extern void mp_GlTexture__delete(void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTexture__Release(IntPtr glTexture);
+        public static extern MpReturnCode mp_GlTexture__Release(void* glTexture);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTexture__GetGpuBufferFrame(IntPtr glTexture, out IntPtr gpuBuffer);
+        public static extern MpReturnCode mp_GlTexture__GetGpuBufferFrame(void* glTexture, out void* gpuBuffer);
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTexture.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlTexture__(out void* glTexture);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTexture.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTexture.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -12,39 +12,39 @@ namespace Mediapipe.Net.Native
     {
         #region GlTextureBuffer
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__WaitUntilComplete(IntPtr glTextureBuffer);
+        public static extern MpReturnCode mp_GlTextureBuffer__WaitUntilComplete(void* glTextureBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__WaitOnGpu(IntPtr glTextureBuffer);
+        public static extern MpReturnCode mp_GlTextureBuffer__WaitOnGpu(void* glTextureBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__Reuse(IntPtr glTextureBuffer);
+        public static extern MpReturnCode mp_GlTextureBuffer__Reuse(void* glTextureBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__Updated__Pgst(IntPtr glTextureBuffer, IntPtr prodToken);
+        public static extern MpReturnCode mp_GlTextureBuffer__Updated__Pgst(void* glTextureBuffer, void* prodToken);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__DidRead__Pgst(IntPtr glTextureBuffer, IntPtr consToken);
+        public static extern MpReturnCode mp_GlTextureBuffer__DidRead__Pgst(void* glTextureBuffer, void* consToken);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__WaitForConsumers(IntPtr glTextureBuffer);
+        public static extern MpReturnCode mp_GlTextureBuffer__WaitForConsumers(void* glTextureBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GlTextureBuffer__WaitForConsumersOnGpu(IntPtr glTextureBuffer);
+        public static extern MpReturnCode mp_GlTextureBuffer__WaitForConsumersOnGpu(void* glTextureBuffer);
         #endregion
 
         #region SharedGlTextureBuffer
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SharedGlTextureBuffer__delete(IntPtr glTextureBuffer);
+        public static extern void mp_SharedGlTextureBuffer__delete(void* glTextureBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SharedGlTextureBuffer__reset(IntPtr glTextureBuffer);
+        public static extern void mp_SharedGlTextureBuffer__reset(void* glTextureBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_SharedGlTextureBuffer__ui_ui_i_i_ui_PF_PSgc(
             uint target, uint name, int width, int height, GpuBufferFormat format,
             GlTextureBuffer.DeletionCallback deletionCallback,
-            IntPtr producerContext, out IntPtr sharedGlTextureBuffer);
+            void* producerContext, out void* sharedGlTextureBuffer);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -43,7 +43,7 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_SharedGlTextureBuffer__ui_ui_i_i_ui_PF_PSgc(
             uint target, uint name, int width, int height, GpuBufferFormat format,
-            [MarshalAs(UnmanagedType.FunctionPtr)] GlTextureBuffer.DeletionCallback deletionCallback,
+            GlTextureBuffer.DeletionCallback deletionCallback,
             IntPtr producerContext, out IntPtr sharedGlTextureBuffer);
         #endregion
     }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.Gpu;
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GlTextureBuffer.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Gpu;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         #region GlTextureBuffer
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBuffer.cs
@@ -12,37 +12,37 @@ namespace Mediapipe.Net.Native
     {
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GpuBuffer__PSgtb(IntPtr glTextureBuffer, out IntPtr gpuBuffer);
+        public static extern MpReturnCode mp_GpuBuffer__PSgtb(void* glTextureBuffer, out void* gpuBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_GpuBuffer__delete(IntPtr gpuBuffer);
+        public static extern void mp_GpuBuffer__delete(void* gpuBuffer);
 
         #region StatusOr
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_StatusOrGpuBuffer__delete(IntPtr statusOrGpuBuffer);
+        public static extern void mp_StatusOrGpuBuffer__delete(void* statusOrGpuBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrGpuBuffer__status(IntPtr statusOrGpuBuffer, out IntPtr status);
+        public static extern MpReturnCode mp_StatusOrGpuBuffer__status(void* statusOrGpuBuffer, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrGpuBuffer__value(IntPtr statusOrGpuBuffer, out IntPtr gpuBuffer);
+        public static extern MpReturnCode mp_StatusOrGpuBuffer__value(void* statusOrGpuBuffer, out void* gpuBuffer);
         #endregion
 
         #region Packet
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeGpuBufferPacket__Rgb(IntPtr gpuBuffer, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeGpuBufferPacket__Rgb(void* gpuBuffer, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeGpuBufferPacket_At__Rgb_Rts(IntPtr gpuBuffer, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeGpuBufferPacket_At__Rgb_Rts(void* gpuBuffer, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ConsumeGpuBuffer(IntPtr packet, out IntPtr statusOrGpuBuffer);
+        public static extern MpReturnCode mp_Packet__ConsumeGpuBuffer(void* packet, out void* statusOrGpuBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetGpuBuffer(IntPtr packet, out IntPtr gpuBuffer);
+        public static extern MpReturnCode mp_Packet__GetGpuBuffer(void* packet, out void* gpuBuffer);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__ValidateAsGpuBuffer(IntPtr packet, out IntPtr status);
+        public static extern MpReturnCode mp_Packet__ValidateAsGpuBuffer(void* packet, out void* status);
         #endregion
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBuffer.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBuffer.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBuffer.cs
@@ -8,7 +8,7 @@ using System.Runtime.Versioning;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [SupportedOSPlatform("Linux"), SupportedOSPlatform("Android")]
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBufferFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuBufferFormat.cs
@@ -7,7 +7,7 @@ using Mediapipe.Net.Gpu;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp__GlTextureInfoForGpuBufferFormat__ui_i_ui(

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuResources.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuResources.cs
@@ -10,24 +10,24 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SharedGpuResources__delete(IntPtr gpuResources);
+        public static extern void mp_SharedGpuResources__delete(void* gpuResources);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_SharedGpuResources__reset(IntPtr gpuResources);
+        public static extern void mp_SharedGpuResources__reset(void* gpuResources);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GpuResources_Create(out IntPtr statusOrGpuResources);
+        public static extern MpReturnCode mp_GpuResources_Create(out void* statusOrGpuResources);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_GpuResources_Create__Pv(IntPtr externalContext, out IntPtr statusOrGpuResources);
+        public static extern MpReturnCode mp_GpuResources_Create__Pv(void* externalContext, out void* statusOrGpuResources);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_StatusOrGpuResources__delete(IntPtr statusOrGpuResources);
+        public static extern void mp_StatusOrGpuResources__delete(void* statusOrGpuResources);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrGpuResources__status(IntPtr statusOrGpuResources, out IntPtr status);
+        public static extern MpReturnCode mp_StatusOrGpuResources__status(void* statusOrGpuResources, out void* status);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_StatusOrGpuResources__value(IntPtr statusOrGpuResources, out IntPtr gpuResources);
+        public static extern MpReturnCode mp_StatusOrGpuResources__value(void* statusOrGpuResources, out void* gpuResources);
     }
 }

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuResources.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Gpu/GpuResources.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_SharedGpuResources__delete(void* gpuResources);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Graphs/InstantMotionTracking.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Graphs/InstantMotionTracking.cs
@@ -8,7 +8,7 @@ using Mediapipe.Net.Graphs.InstantMotionTracking;
 
 namespace Mediapipe.Net.Native
 {
-    internal partial class UnsafeNativeMethods : NativeMethods
+    internal unsafe partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp__MakeAnchor3dVectorPacket__PA_i(Anchor3d[] value, int size, out void* packet);

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Graphs/InstantMotionTracking.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Graphs/InstantMotionTracking.cs
@@ -2,7 +2,6 @@
 // This file is part of MediaPipe.NET.
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
-using System;
 using System.Runtime.InteropServices;
 using Mediapipe.Net.Graphs.InstantMotionTracking;
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Graphs/InstantMotionTracking.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Graphs/InstantMotionTracking.cs
@@ -11,15 +11,15 @@ namespace Mediapipe.Net.Native
     internal partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeAnchor3dVectorPacket__PA_i(Anchor3d[] value, int size, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeAnchor3dVectorPacket__PA_i(Anchor3d[] value, int size, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp__MakeAnchor3dVectorPacket_At__PA_i_Rt(Anchor3d[] value, int size, IntPtr timestamp, out IntPtr packet);
+        public static extern MpReturnCode mp__MakeAnchor3dVectorPacket_At__PA_i_Rt(Anchor3d[] value, int size, void* timestamp, out void* packet);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp_Anchor3dArray__delete(IntPtr anchorVectorData);
+        public static extern void mp_Anchor3dArray__delete(void* anchorVectorData);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Packet__GetAnchor3dVector(IntPtr packet, out Anchor3dVector anchorVector);
+        public static extern MpReturnCode mp_Packet__GetAnchor3dVector(void* packet, out Anchor3dVector anchorVector);
     }
 }

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -15,7 +15,7 @@ namespace Mediapipe.Net.Util
     /// <remarks>
     /// There must not be more than one instance at the same time.
     /// </remarks>
-    public abstract class ResourceManager
+    public unsafe abstract class ResourceManager
     {
         public delegate string PathResolver(string path);
         public abstract PathResolver ResolvePath { get; }

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -19,7 +19,7 @@ namespace Mediapipe.Net.Util
     {
         public delegate string PathResolver(string path);
         public abstract PathResolver ResolvePath { get; }
-        public delegate bool ResourceProvider(string path, IntPtr output);
+        public delegate bool ResourceProvider(string path, void* output);
         public abstract ResourceProvider ProvideResource { get; }
 
         private static readonly object initLock = new object();

--- a/Mediapipe.Net/Util/UnsafeUtil.cs
+++ b/Mediapipe.Net/Util/UnsafeUtil.cs
@@ -6,6 +6,18 @@ namespace Mediapipe.Net.Util
 {
     internal unsafe static class UnsafeUtil
     {
+        /// <summary>
+        /// Copies all objects from an unsafe array to a safe array.
+        /// </summary>
+        /// <param name="ptr">The pointer array of objects.</param>
+        /// <param name="length">The number of elements inside of the unsafe array.</param>
+        /// <typeparam name="T">The type of elements in the array.</typeparam>
+        /// <remarks>
+        /// It doesn't do any kind of deep copy of the elements.
+        /// So if the object of type T contains references to other objects,
+        /// the references will be copied and not the objects themselves.
+        /// </remarks>
+        /// <returns>A safe array containing a copy of the elements from the unsafe array.</returns>
         public static T[] SafeArrayCopy<T>(T* ptr, int length)
             where T : unmanaged
         {

--- a/Mediapipe.Net/Util/UnsafeUtil.cs
+++ b/Mediapipe.Net/Util/UnsafeUtil.cs
@@ -1,0 +1,18 @@
+// Copyright (c) homuler and Vignette
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+namespace Mediapipe.Net.Util
+{
+    internal unsafe static class UnsafeUtil
+    {
+        public static T[] SafeArrayCopy<T>(T* ptr, int length)
+            where T : unmanaged
+        {
+            T[] array = new T[length];
+            for (int i = 0; i < array.Length; i++)
+                array[i] = ptr[i];
+            return array;
+        }
+    }
+}


### PR DESCRIPTION
This is a big one that needs a lot of investigation.
Here's what I've done so far:
- remove `MarshalAs` attributes from `bool`-typed parameters;
- instead of having a `[return: MarshalAs(...)]` attribute on native methods that return a bool, I return a `byte` and add `> 0` in C# code to convert to the actual C++ boolean;
- replace every `IntPtr` with `void*` - *except* for `Packet<T>` types because of the Activator, that would unfortunately need a whole restructuration of the Packet API;
- mark a lot of classes as `unsafe`;
- replace `Marshal.PtrToStructure` with unsafe pointer arithmetic.

I also plan on changing the string types that are currently just `void*`s so that I can remove more `Marshal`s and instead directly use `new string(sbyte*)`.