### PR TITLE
Make `Calculator` more thread-safe

### DIFF
--- a/Mediapipe.Net.Examples.FaceMeshGpu/Program.cs
+++ b/Mediapipe.Net.Examples.FaceMeshGpu/Program.cs
@@ -82,7 +82,6 @@ namespace Mediapipe.Net.Examples.FaceMeshGpu
                     cFrame.Width, cFrame.Height, cFrame.WidthStep, cFrame.RawData);
 
                 using ImageFrame img = calculator.Send(imgframe);
-                imgframe.Dispose();
             }
         }
 

--- a/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
+++ b/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
@@ -64,7 +64,6 @@ namespace Mediapipe.Net.Examples.OsuFrameworkVisualTests
             ImageFrame imgFrame = new ImageFrame(ImageFormat.Srgba,
                 cFrame.Width, cFrame.Height, cFrame.WidthStep, cFrame.RawData);
             using ImageFrame outImgFrame = calculator.Send(imgFrame);
-            imgFrame.Dispose();
 
             var span = new ReadOnlySpan<byte>(outImgFrame.MutablePixelData, outImgFrame.Height * outImgFrame.WidthStep);
             var pixelData = Image.LoadPixelData<Rgba32>(span, cFrame.Width, cFrame.Height);

--- a/Mediapipe.Net/Calculators/Calculator.cs
+++ b/Mediapipe.Net/Calculators/Calculator.cs
@@ -70,11 +70,14 @@ namespace Mediapipe.Net.Calculators
         /// </summary>
         /// <remarks>If the input <see cref="ImageFrame"/> doesn't get disposed after being sent, MediaPipe will crash.</remarks>
         /// <param name="frame">The frame that MediaPipe should process.</param>
+        /// <param name="disposeSourceFrame">Whether or not to dispose the source frame.</param>
         /// <returns>An <see cref="ImageFrame"/> with the contents of the source <see cref="ImageFrame"/> and the MediaPipe solution drawn.</returns>
-        public ImageFrame Send(ImageFrame frame)
+        public ImageFrame Send(ImageFrame frame, bool disposeSourceFrame = true)
         {
             ImageFrame outFrame = SendFrame(frame);
             CurrentFrame++;
+            if (disposeSourceFrame)
+                frame.Dispose();
             return outFrame;
         }
 

--- a/Mediapipe.Net/Calculators/Calculator.cs
+++ b/Mediapipe.Net/Calculators/Calculator.cs
@@ -74,11 +74,14 @@ namespace Mediapipe.Net.Calculators
         /// <returns>An <see cref="ImageFrame"/> with the contents of the source <see cref="ImageFrame"/> and the MediaPipe solution drawn.</returns>
         public ImageFrame Send(ImageFrame frame, bool disposeSourceFrame = true)
         {
-            ImageFrame outFrame = SendFrame(frame);
-            CurrentFrame++;
-            if (disposeSourceFrame)
-                frame.Dispose();
-            return outFrame;
+            lock (frame)
+            {
+                ImageFrame outFrame = SendFrame(frame);
+                CurrentFrame++;
+                if (disposeSourceFrame)
+                    frame.Dispose();
+                return outFrame;
+            }
         }
 
         /// <summary>

--- a/Mediapipe.Net/Calculators/Calculator.cs
+++ b/Mediapipe.Net/Calculators/Calculator.cs
@@ -29,7 +29,7 @@ namespace Mediapipe.Net.Calculators
         protected readonly string? SecondaryOutputStream;
 
         protected readonly CalculatorGraph Graph;
-        private GCHandle observeStreamHandle;
+        private GCHandle? observeStreamHandle;
 
         /// <summary>
         /// Triggered every time the calculator returns a secondary output.
@@ -53,7 +53,8 @@ namespace Mediapipe.Net.Calculators
                     T secondaryOutput = packet.Get();
                     OnResult?.Invoke(this, secondaryOutput);
                     return Status.Ok();
-                }, out observeStreamHandle).AssertOk();
+                }, out GCHandle handle).AssertOk();
+                observeStreamHandle = handle;
             }
         }
 
@@ -95,7 +96,7 @@ namespace Mediapipe.Net.Calculators
             Graph.WaitUntilDone();
             Graph.Dispose();
 
-            observeStreamHandle.Free();
+            observeStreamHandle?.Free();
         }
     }
 }

--- a/Mediapipe.Net/Calculators/HolisticCpuCalculator.cs
+++ b/Mediapipe.Net/Calculators/HolisticCpuCalculator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) homuler and The Vignette Authors
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework.Packet;
+
+namespace Mediapipe.Net.Calculators
+{
+    public sealed class HolisticCpuCalculator : CpuCalculator<BoolPacket, bool>
+    {
+        public HolisticCpuCalculator() : base(
+            graphPath: "mediapipe/graphs/holistic_tracking/holistic_tracking_cpu.pbtxt")
+        {
+        }
+    }
+}

--- a/Mediapipe.Net/Calculators/HolisticGpuCalculator.cs
+++ b/Mediapipe.Net/Calculators/HolisticGpuCalculator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) homuler and The Vignette Authors
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using Mediapipe.Net.Framework.Packet;
+
+namespace Mediapipe.Net.Calculators
+{
+    public sealed class HolisticGpuCalculator : CpuCalculator<BoolPacket, bool>
+    {
+        public HolisticGpuCalculator() : base(
+            graphPath: "mediapipe/graphs/holistic_tracking/holistic_tracking_gpu.pbtxt")
+        {
+        }
+    }
+}


### PR DESCRIPTION
- [x] Auto dispose source frame when calling `Calculator.Send(ImageFrame frame)`, with it being opt-out
- [x] Lock a frame while it is being processed
- [x] Add holistic calculator
- [x] More stuff
- [x] Useless dopamine dispenser checkbox number one
- [x] Useless dopamine dispenser checkbox number two