### PR TITLE
Refactor resource provider

### DIFF
--- a/Mediapipe.Net.Examples.FaceMesh/DummyResourceManager.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/DummyResourceManager.cs
@@ -1,0 +1,41 @@
+// Copyright (c) homuler and The Vignette Authors
+// This file is part of MediaPipe.NET.
+// MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
+
+using System;
+using System.Collections;
+using System.IO;
+using Mediapipe.Net.External;
+using Mediapipe.Net.Util;
+
+namespace Mediapipe.Net.Examples.FaceMesh
+{
+    public class DummyResourceManager : ResourceManager
+    {
+        public override PathResolver ResolvePath => (path) =>
+        {
+            Console.WriteLine($"PathResolver: (not) resolving path '{path}'");
+            // return GetAssetNameFromPath(path);
+            return path;
+        };
+
+        public unsafe override ResourceProvider ProvideResource => (path, output) =>
+        {
+            Console.WriteLine($"ResourceProvider: providing resource '{path}'");
+            using StdString strOutput = new StdString(output, false);
+            using StdString resource = new StdString(File.ReadAllBytes(path));
+            resource.Swap(strOutput);
+            return true;
+        };
+
+        public override bool IsPrepared(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IEnumerator PrepareAssetAsync(string name, string uniqueKey, bool overwrite = true)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Mediapipe.Net.Examples.FaceMesh/DummyResourceManager.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/DummyResourceManager.cs
@@ -13,7 +13,6 @@ namespace Mediapipe.Net.Examples.FaceMesh
         public override PathResolver ResolvePath => (path) =>
         {
             Console.WriteLine($"PathResolver: (not) resolving path '{path}'");
-            // return GetAssetNameFromPath(path);
             return path;
         };
 

--- a/Mediapipe.Net.Examples.FaceMesh/DummyResourceManager.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/DummyResourceManager.cs
@@ -3,9 +3,7 @@
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
 using System;
-using System.Collections;
 using System.IO;
-using Mediapipe.Net.External;
 using Mediapipe.Net.Util;
 
 namespace Mediapipe.Net.Examples.FaceMesh
@@ -19,23 +17,11 @@ namespace Mediapipe.Net.Examples.FaceMesh
             return path;
         };
 
-        public unsafe override ResourceProvider ProvideResource => (path, output) =>
+        public unsafe override ResourceProvider ProvideResource => (path) =>
         {
             Console.WriteLine($"ResourceProvider: providing resource '{path}'");
-            using StdString strOutput = new StdString(output, false);
-            using StdString resource = new StdString(File.ReadAllBytes(path));
-            resource.Swap(strOutput);
-            return true;
+            byte[] bytes = File.ReadAllBytes(path);
+            return bytes;
         };
-
-        public override bool IsPrepared(string name)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override IEnumerator PrepareAssetAsync(string name, string uniqueKey, bool overwrite = true)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/Mediapipe.Net.Examples.FaceMesh/Options.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/Options.cs
@@ -23,7 +23,7 @@ namespace Mediapipe.Net.Examples.FaceMesh
         [Option('h', "height", Default = null, HelpText = "The height of the camera input")]
         public int? Height { get; set; }
 
-        [Option("--use-resource-manager", Default = false, HelpText = "Whether to use a resource manager.")]
+        [Option("use-resource-manager", Default = false, HelpText = "Whether to use a resource manager.")]
         public bool UseResourceManager { get; set; }
     }
 }

--- a/Mediapipe.Net.Examples.FaceMesh/Options.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/Options.cs
@@ -22,5 +22,8 @@ namespace Mediapipe.Net.Examples.FaceMesh
 
         [Option('h', "height", Default = null, HelpText = "The height of the camera input")]
         public int? Height { get; set; }
+
+        [Option("--use-resource-manager", Default = false, HelpText = "Whether to use a resource manager.")]
+        public bool UseResourceManager { get; set; }
     }
 }

--- a/Mediapipe.Net.Examples.FaceMesh/Program.cs
+++ b/Mediapipe.Net.Examples.FaceMesh/Program.cs
@@ -10,6 +10,7 @@ using Mediapipe.Net.Calculators;
 using Mediapipe.Net.External;
 using Mediapipe.Net.Framework.Format;
 using Mediapipe.Net.Framework.Protobuf;
+using Mediapipe.Net.Util;
 using SeeShark;
 using SeeShark.Device;
 using SeeShark.FFmpeg;
@@ -21,6 +22,7 @@ namespace Mediapipe.Net.Examples.FaceMesh
         private static Camera? camera;
         private static FrameConverter? converter;
         private static FaceMeshCpuCalculator? calculator;
+        private static ResourceManager? resourceManager;
 
         public static void Main(string[] args)
         {
@@ -37,6 +39,8 @@ namespace Mediapipe.Net.Examples.FaceMesh
 
             FFmpegManager.SetupFFmpeg("/usr/lib");
             Glog.Initialize("stuff");
+            if (parsed.UseResourceManager)
+                resourceManager = new DummyResourceManager();
 
             // Get a camera device
             using (CameraManager manager = new CameraManager())

--- a/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
+++ b/Mediapipe.Net/Native/SafeNativeMethods/Utils/ResourceUtil.cs
@@ -9,9 +9,10 @@ namespace Mediapipe.Net.Native
 {
     internal unsafe partial class SafeNativeMethods : NativeMethods
     {
+        public delegate bool UnsafeResourceProvider(string path, void* output);
+
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void mp__SetCustomGlobalResourceProvider__P(
-            ResourceManager.ResourceProvider provider);
+        public static extern void mp__SetCustomGlobalResourceProvider__P(UnsafeResourceProvider provider);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp__SetCustomGlobalPathResolver__P(

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/External/Stdlib.cs
@@ -13,10 +13,10 @@ namespace Mediapipe.Net.Native
 
         #region String
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern void std_string__delete(sbyte* str);
+        public static extern void std_string__delete(void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode std_string__PKc_i(byte[] bytes, int size, out sbyte* str);
+        public static extern MpReturnCode std_string__PKc_i(byte[] bytes, int size, out void* str);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void std_string__swap__Rstr(void* src, void* dst);

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -3,14 +3,13 @@
 // MediaPipe.NET is licensed under the MIT License. See LICENSE for details.
 
 using System;
-using System.Collections;
-using System.IO;
+using Mediapipe.Net.External;
 using Mediapipe.Net.Native;
 
 namespace Mediapipe.Net.Util
 {
     /// <summary>
-    /// Class to manage assets that MediaPipe accesses.
+    /// Class to manage MediaPipe resources, such as `.tflite` and `.pbtxt` files that it requests.
     /// </summary>
     /// <remarks>
     /// There must not be more than one instance at the same time.
@@ -19,7 +18,8 @@ namespace Mediapipe.Net.Util
     {
         public delegate string PathResolver(string path);
         public abstract PathResolver ResolvePath { get; }
-        public delegate bool ResourceProvider(string path, void* output);
+
+        public delegate Span<byte> ResourceProvider(string path);
         public abstract ResourceProvider ProvideResource { get; }
 
         private static readonly object initLock = new object();
@@ -33,43 +33,25 @@ namespace Mediapipe.Net.Util
                     throw new InvalidOperationException("ResourceManager can be initialized only once");
 
                 SafeNativeMethods.mp__SetCustomGlobalPathResolver__P(ResolvePath);
-                SafeNativeMethods.mp__SetCustomGlobalResourceProvider__P(ProvideResource);
+                SafeNativeMethods.mp__SetCustomGlobalResourceProvider__P(provideResource);
                 isInitialized = true;
             }
         }
 
-        /// <param name="name">Asset name</param>
-        /// <returns>
-        ///   Returns true if <paramref name="name" /> is already prepared (saved locally on the device).
-        /// </returns>
-        public abstract bool IsPrepared(string name);
-
-        /// <summary>
-        ///   Saves <paramref name="name" /> as <paramref name="uniqueKey" /> asynchronously.
-        /// </summary>
-        /// <param name="overwrite">
-        ///   Specifies whether <paramref name="uniqueKey" /> will be overwritten if it already exists.
-        /// </param>
-        public abstract IEnumerator PrepareAssetAsync(string name, string uniqueKey, bool overwrite = true);
-
-        public IEnumerator PrepareAssetAsync(string name, bool overwrite = true)
-            => PrepareAssetAsync(name, name, overwrite);
-
-        protected static string GetAssetNameFromPath(string assetPath)
+        private bool provideResource(string path, void* output)
         {
-            var assetName = Path.GetFileNameWithoutExtension(assetPath);
-            var extension = Path.GetExtension(assetPath);
+            Span<byte> span = ProvideResource(path);
+            if (span.IsEmpty)
+                return false;
 
-            switch (extension)
+            fixed (void* spanPtr = span)
             {
-                case ".binarypb":
-                case ".tflite":
-                    return $"{assetName}.bytes";
-                case ".pbtxt":
-                    return $"{assetName}.txt";
-                default:
-                    return $"{assetName}{extension}";
+                using StdString strOutput = new StdString(output, isOwner: false);
+                using StdString strSpan = new StdString(spanPtr, isOwner: true);
+                strOutput.Swap(strSpan);
             }
+
+            return true;
         }
     }
 }

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -17,8 +17,18 @@ namespace Mediapipe.Net.Util
     public unsafe abstract class ResourceManager
     {
         public delegate string PathResolver(string path);
+
+        /// <summary>
+        /// Resolves a path to a resource name.
+        /// If the resource name returned is different from the path, the <see cref="ResourceProvider" /> delegate will receive the resource name instead of the file path.
+        /// </summary>
         public abstract PathResolver ResolvePath { get; }
 
+        /// <summary>
+        /// Reads a resource that MediaPipe requests.
+        /// </summary>
+        /// <param name="path">File path or name of the resource.</param>
+        /// <returns>Content of the MediaPipe resource as a byte array.</returns>
         public delegate byte[] ResourceProvider(string path);
         public abstract ResourceProvider ProvideResource { get; }
 

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -40,15 +40,21 @@ namespace Mediapipe.Net.Util
 
         private bool provideResource(string path, void* output)
         {
-            byte[] bytes = ProvideResource(path);
-            if (bytes.Length == 0)
+            try
+            {
+                byte[] bytes = ProvideResource(path);
+
+                StdString strOutput = new StdString(output, isOwner: false);
+                StdString strSpan = new StdString(bytes);
+                strOutput.Swap(strSpan);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Glog.Log(Glog.Severity.Error, $"Error while trying to provide resource '{path}': {ex}");
                 return false;
-
-            StdString strOutput = new StdString(output, isOwner: false);
-            StdString strSpan = new StdString(bytes);
-            strOutput.Swap(strSpan);
-
-            return true;
+            }
         }
     }
 }

--- a/Mediapipe.Net/Util/ResourceManager.cs
+++ b/Mediapipe.Net/Util/ResourceManager.cs
@@ -19,7 +19,7 @@ namespace Mediapipe.Net.Util
         public delegate string PathResolver(string path);
         public abstract PathResolver ResolvePath { get; }
 
-        public delegate Span<byte> ResourceProvider(string path);
+        public delegate byte[] ResourceProvider(string path);
         public abstract ResourceProvider ProvideResource { get; }
 
         private static readonly object initLock = new object();
@@ -40,16 +40,13 @@ namespace Mediapipe.Net.Util
 
         private bool provideResource(string path, void* output)
         {
-            Span<byte> span = ProvideResource(path);
-            if (span.IsEmpty)
+            byte[] bytes = ProvideResource(path);
+            if (bytes.Length == 0)
                 return false;
 
-            fixed (void* spanPtr = span)
-            {
-                using StdString strOutput = new StdString(output, isOwner: false);
-                using StdString strSpan = new StdString(spanPtr, isOwner: true);
-                strOutput.Swap(strSpan);
-            }
+            StdString strOutput = new StdString(output, isOwner: false);
+            StdString strSpan = new StdString(bytes);
+            strOutput.Swap(strSpan);
 
             return true;
         }


### PR DESCRIPTION
This is the final PR before we finally release MediaPipe.NET in a Nuget package. It will let us customize how we manage our resources.
I provided an example `DummyResourceManager` in the `FaceMesh` example.

Note: I'd like to use a `Span<byte>` ideally instead of a `byte[]` as @LeNitrous requested, but it segfaulted unfortunately.
I may have coded that wrong and need to change more things in order for it to work. I'll experiment with this a bit later today.

- [ ] Use `Span<byte>` instead of `byte[]`