### PR TITLE
fix incorrect ImageFrame memory ownership handling

### DIFF
--- a/Mediapipe.Net.Examples.BlazePose/Mediapipe.Net.Examples.BlazePose.csproj
+++ b/Mediapipe.Net.Examples.BlazePose/Mediapipe.Net.Examples.BlazePose.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9" />
+    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9.1" />
     <PackageReference Include="SeeShark" Version="3.0.0" />
   </ItemGroup>
 

--- a/Mediapipe.Net.Examples.FaceMesh/Mediapipe.Net.Examples.FaceMesh.csproj
+++ b/Mediapipe.Net.Examples.FaceMesh/Mediapipe.Net.Examples.FaceMesh.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9" />
+    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9.1" />
     <PackageReference Include="SeeShark" Version="3.0.0" />
   </ItemGroup>
 

--- a/Mediapipe.Net.Examples.FaceMeshGpu/Mediapipe.Net.Examples.FaceMeshGpu.csproj
+++ b/Mediapipe.Net.Examples.FaceMeshGpu/Mediapipe.Net.Examples.FaceMeshGpu.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="Mediapipe.Net.Runtime.GPU" Version="0.8.9" />
+    <PackageReference Include="Mediapipe.Net.Runtime.GPU" Version="0.8.9.1" />
     <PackageReference Include="SeeShark" Version="3.0.0" />
   </ItemGroup>
 

--- a/Mediapipe.Net.Examples.OsuFrameworkVisualTests/Mediapipe.Net.Examples.OsuFrameworkVisualTests.csproj
+++ b/Mediapipe.Net.Examples.OsuFrameworkVisualTests/Mediapipe.Net.Examples.OsuFrameworkVisualTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
-    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9" />
+    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.217.0" />

--- a/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
+++ b/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
@@ -66,7 +66,8 @@ namespace Mediapipe.Net.Examples.OsuFrameworkVisualTests
             ImageFrame imgFrame = new ImageFrame(ImageFormat.Srgba,
                 cFrame.Width, cFrame.Height, cFrame.WidthStep, cFrame.RawData);
             using ImageFrame? outImgFrame = calculator.Send(imgFrame);
-            if (outImgFrame == null) return;
+            if (outImgFrame == null)
+                return;
 
             var span = new ReadOnlySpan<byte>(outImgFrame.MutablePixelData, outImgFrame.Height * outImgFrame.WidthStep);
             var pixelData = Image.LoadPixelData<Rgba32>(span, cFrame.Width, cFrame.Height);

--- a/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
+++ b/Mediapipe.Net.Examples.OsuFrameworkVisualTests/MediapipeDrawable.cs
@@ -48,18 +48,20 @@ namespace Mediapipe.Net.Examples.OsuFrameworkVisualTests
             this.camera = camera;
             this.converter = converter;
             this.calculator = calculator;
+            this.camera.OnFrame += onFrameEventHandler;
+            this.camera.StartCapture();
         }
 #pragma warning restore IDE0051
 
-        protected override unsafe void Update()
+        private unsafe void onFrameEventHandler(object? sender, FrameEventArgs e)
         {
-            base.Update();
-            if (camera == null || converter == null || calculator == null)
+            if (converter == null || calculator == null)
                 return;
 
-            if (camera.TryGetFrame(out Frame frame) != DecodeStatus.NewFrame)
+            if (e.Status != DecodeStatus.NewFrame)
                 return;
 
+            Frame frame = e.Frame;
             Frame cFrame = converter.Convert(frame);
             ImageFrame imgFrame = new ImageFrame(ImageFormat.Srgba,
                 cFrame.Width, cFrame.Height, cFrame.WidthStep, cFrame.RawData);

--- a/Mediapipe.Net.Examples.OsuFrameworkVisualTests/OsuFrameworkVisualTestsGameBase.cs
+++ b/Mediapipe.Net.Examples.OsuFrameworkVisualTests/OsuFrameworkVisualTestsGameBase.cs
@@ -67,7 +67,7 @@ namespace Mediapipe.Net.Examples.OsuFrameworkVisualTests
             manager.Dispose();
 
             var dummyFrame = camera.GetFrame();
-            converter = new FrameConverter(dummyFrame, PixelFormat.Rgba);
+            converter = new FrameConverter(dummyFrame, dummyFrame.Width / 2, dummyFrame.Height / 2, PixelFormat.Rgba);
             dependencies?.Cache(converter);
 
             calculator = new FaceMeshCpuCalculator();

--- a/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
+++ b/Mediapipe.Net.Tests/Framework/Format/ImageFrameTest.cs
@@ -70,24 +70,20 @@ namespace Mediapipe.Net.Tests.Framework.Format
         }
 
         [Test]
-        unsafe public void Ctor_ShouldInstantiateImageFrame_When_CalledWithPixelData()
+        public void Ctor_ShouldInstantiateImageFrame_When_CalledWithPixelData()
         {
             byte[] srcBytes = new byte[] {
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
             };
-            byte[] dupBytes = srcBytes.ToArray();
 
-            fixed (byte* pixelData = dupBytes)
-            {
-                using var imageFrame = new ImageFrame(ImageFormat.Sbgra, 4, 2, 16, pixelData);
-                Assert.AreEqual(imageFrame.Width, 4);
-                Assert.AreEqual(imageFrame.Height, 2);
-                Assert.False(imageFrame.IsEmpty);
+            using var imageFrame = new ImageFrame(ImageFormat.Sbgra, 4, 2, 16, srcBytes);
+            Assert.AreEqual(imageFrame.Width, 4);
+            Assert.AreEqual(imageFrame.Height, 2);
+            Assert.False(imageFrame.IsEmpty);
 
-                var bytes = imageFrame.CopyToByteBuffer(32);
-                Assert.IsEmpty(bytes.Where((x, i) => x != srcBytes[i]));
-            }
+            byte[] bytes = imageFrame.CopyToByteBuffer(srcBytes.Length);
+            Assert.IsEmpty(bytes.Where((x, i) => x != srcBytes[i]));
         }
 
         [Test, SignalAbort]

--- a/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
+++ b/Mediapipe.Net.Tests/Mediapipe.Net.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup Label="Package references">
     <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
-    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9" />
-    <!-- <PackageReference Include="Mediapipe.Net.Runtime.GPU" Version="0.8.9" /> -->
+    <PackageReference Include="Mediapipe.Net.Runtime.CPU" Version="0.8.9.1" />
+    <!-- <PackageReference Include="Mediapipe.Net.Runtime.GPU" Version="0.8.9.1" /> -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -14,10 +14,6 @@ namespace Mediapipe.Net.Framework.Format
         public static readonly uint DefaultAlignmentBoundary = 16;
         public static readonly uint GlDefaultAlignmentBoundary = 4;
 
-        public delegate void Deleter(void* ptr);
-        private readonly Deleter? deleter;
-        private GCHandle? deleterHandle;
-
         public ImageFrame() : base()
         {
             UnsafeNativeMethods.mp_ImageFrame__(out var ptr).Assert();
@@ -41,31 +37,23 @@ namespace Mediapipe.Net.Framework.Format
         // MP_CAPI(MpReturnCode) mp_ImageFrame__ui_i_i_i_Pui8_PF(
         //     mediapipe::ImageFormat::Format format,
         //     int width, int height, int width_step, uint8* pixel_data,
-        //     Deleter* deleter, mediapipe::ImageFrame** image_frame_out);
+        //     mediapipe::ImageFrame** image_frame_out);
         public unsafe ImageFrame(ImageFormat format, int width, int height, int widthStep, byte* pixelData) : base()
         {
-            deleter = new Deleter(releasePixelData);
-            deleterHandle = GCHandle.Alloc(deleter);
-
             UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
                 format, width, height, widthStep,
                 pixelData,
-                deleter,
                 out var ptr).Assert();
             Ptr = ptr;
         }
 
         public ImageFrame(ImageFormat format, int width, int height, int widthStep, ReadOnlySpan<byte> pixelData)
         {
-            deleter = releasePixelData;
-            deleterHandle = GCHandle.Alloc(deleter);
-
             fixed (byte* pixelDataPtr = pixelData)
             {
                 UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
                     format, width, height, widthStep,
                     pixelDataPtr,
-                    deleter,
                     out var ptr).Assert();
                 Ptr = ptr;
             }
@@ -81,10 +69,6 @@ namespace Mediapipe.Net.Framework.Format
         protected override void DisposeUnmanaged()
         {
             base.DisposeUnmanaged();
-
-            // `deleter` must not be garbage collected until unmanaged code calls it.
-            if (deleterHandle is GCHandle handle && handle.IsAllocated)
-                handle.Free();
         }
 
         public bool IsEmpty => SafeNativeMethods.mp_ImageFrame__IsEmpty(MpPtr) > 0;

--- a/Mediapipe.Net/Framework/Format/ImageFrame.cs
+++ b/Mediapipe.Net/Framework/Format/ImageFrame.cs
@@ -30,28 +30,23 @@ namespace Mediapipe.Net.Framework.Format
             Ptr = ptr;
         }
 
-        // NOTE: This byte* was a NativeArray<byte> from Unity.
-        // It will naturally translate to C++'s uint8*.
-        // The signature on the native side is:
-        //
-        // MP_CAPI(MpReturnCode) mp_ImageFrame__ui_i_i_i_Pui8_PF(
-        //     mediapipe::ImageFormat::Format format,
-        //     int width, int height, int width_step, uint8* pixel_data,
-        //     mediapipe::ImageFrame** image_frame_out);
-        public unsafe ImageFrame(ImageFormat format, int width, int height, int widthStep, byte* pixelData) : base()
-        {
-            UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
-                format, width, height, widthStep,
-                pixelData,
-                out var ptr).Assert();
-            Ptr = ptr;
-        }
-
-        public ImageFrame(ImageFormat format, int width, int height, int widthStep, ReadOnlySpan<byte> pixelData)
+        public unsafe ImageFrame(ImageFormat format, int width, int height, int widthStep, byte[] pixelData) : base()
         {
             fixed (byte* pixelDataPtr = pixelData)
             {
-                UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
+                UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8(
+                    format, width, height, widthStep,
+                    pixelDataPtr,
+                    out var ptr).Assert();
+                Ptr = ptr;
+            }
+        }
+
+        public ImageFrame(ImageFormat format, int width, int height, int widthStep, ReadOnlySpan<byte> pixelData) : base()
+        {
+            fixed (byte* pixelDataPtr = pixelData)
+            {
+                UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8(
                     format, width, height, widthStep,
                     pixelDataPtr,
                     out var ptr).Assert();
@@ -60,16 +55,6 @@ namespace Mediapipe.Net.Framework.Format
         }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_ImageFrame__delete(Ptr);
-
-        private static void releasePixelData(void* ptr)
-        {
-            // Do nothing (pixelData is moved)
-        }
-
-        protected override void DisposeUnmanaged()
-        {
-            base.DisposeUnmanaged();
-        }
 
         public bool IsEmpty => SafeNativeMethods.mp_ImageFrame__IsEmpty(MpPtr) > 0;
 

--- a/Mediapipe.Net/Mediapipe.Net.csproj
+++ b/Mediapipe.Net/Mediapipe.Net.csproj
@@ -8,15 +8,10 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References">
-    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
-    <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
-  </ItemGroup>
-
   <PropertyGroup Label="Nuget">
     <IsPackable>true</IsPackable>
     <PackageId>Mediapipe.Net</PackageId>
-    <Version>0.8.10</Version>
+    <Version>0.8.9.1</Version>
     <Authors>homuler;Vignette</Authors>
     <PackageTags>Google;Mediapipe;Tracking;Media Analysis</PackageTags>
     <Title>Mediapipe.Net</Title>
@@ -25,6 +20,11 @@
     <PackageProjectUrl>https://github.com/vignetteapp/MediaPipe.NET</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Mediapipe.Net.Framework.Protobuf" Version="0.8.9" />
+  </ItemGroup>
 
   <ItemGroup Label="Documents">
     <None Include="..\LICENSE" Pack="true" PackagePath="" />

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -17,7 +17,7 @@ namespace Mediapipe.Net.Native
             ImageFormat format, int width, int height, uint alignmentBoundary, out void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
-        public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8_PF(
+        public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8(
             ImageFormat format, int width, int height, int widthStep, byte* pixelData,
             out void* imageFrame);
 

--- a/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
+++ b/Mediapipe.Net/Native/UnsafeNativeMethods/Framework/Format/ImageFormat.cs
@@ -19,7 +19,7 @@ namespace Mediapipe.Net.Native
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8_PF(
             ImageFormat format, int width, int height, int widthStep, byte* pixelData,
-            ImageFrame.Deleter deleter, out void* imageFrame);
+            out void* imageFrame);
 
         [DllImport(MEDIAPIPE_LIBRARY, ExactSpelling = true)]
         public static extern void mp_ImageFrame__delete(void* imageFrame);


### PR DESCRIPTION
`mediapipe::ImageFrame` acquires ownership of the original `pixel_data` instead of copying it internally. If `pixel_data` is from .NET-managed memory, it may be garbage collected at any time, causing MediaPipe to crash.

So I think the best way to do it right is to make a copy of `pixel_data` and let `mediapipe::ImageFrame` take ownership of that copy.

This change must be combined with https://github.com/vignetteapp/MediaPipe.NET.Runtime/pull/11